### PR TITLE
Target MC 1.21.1 + NeoForge 21.1.221 via Connector

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,13 @@
 org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.21.11
-yarn_mappings=1.21.11+build.4
-loader_version=0.18.1
+minecraft_version=1.21.1
+yarn_mappings=1.21.1+build.3
+loader_version=0.16.9
 # Mod Properties
 mod_version=2.0.4
 maven_group=com.github.xandergos
 archives_base_name=terrain-diffusion-mc
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.141.2+1.21.11
+fabric_version=0.116.11+1.21.1

--- a/src/client/java/com/github/xandergos/terraindiffusionmc/mixin/client/CreateWorldScreenWorldTabMixin.java
+++ b/src/client/java/com/github/xandergos/terraindiffusionmc/mixin/client/CreateWorldScreenWorldTabMixin.java
@@ -19,6 +19,12 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 /**
  * Reuses vanilla's World tab "Customize" button for Terrain Diffusion worlds.
+ *
+ * NOTE FOR MC 1.21.1: The intermediary names below (field_42182, method_48676,
+ * method_48680, method_48681) were valid for MC 1.21.11. You must verify the
+ * correct 1.21.1 intermediary names via the Yarn mappings at:
+ *   https://github.com/FabricMC/yarn/tree/1.21.1+build.3/mappings/net/minecraft/client/gui/screen/world
+ * or by running: ./gradlew genSources and inspecting CreateWorldScreen$WorldTab.
  */
 @Mixin(targets = "net.minecraft.client.gui.screen.world.CreateWorldScreen$WorldTab")
 public abstract class CreateWorldScreenWorldTabMixin {

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/TerrainDiffusionMc.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/TerrainDiffusionMc.java
@@ -18,7 +18,6 @@ import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.ClickEvent;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
-import java.net.URI;
 import net.minecraft.util.Identifier;
 import net.minecraft.world.World;
 import org.slf4j.Logger;
@@ -60,7 +59,7 @@ public class TerrainDiffusionMc implements ModInitializer {
             int port = ExplorerServer.startIfNotRunning();
             String url = "http://localhost:" + port;
             MutableText link = Text.literal(url)
-                    .styled(s -> s.withClickEvent(new ClickEvent.OpenUrl(URI.create(url)))
+                    .styled(s -> s.withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, url))
                                   .withUnderline(true));
             ctx.getSource().sendFeedback(
                     () -> Text.literal("Terrain Explorer: ").append(link),

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/mixin/BiomeMixin.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/mixin/BiomeMixin.java
@@ -18,7 +18,7 @@ public abstract class BiomeMixin {
     public abstract boolean hasPrecipitation();
 
     @Inject(method = "getPrecipitation", at = @At("HEAD"), cancellable = true)
-    private void preventHighAltitudeSnow(BlockPos pos, int seaLevel, CallbackInfoReturnable<Biome.Precipitation> cir) {
+    private void preventHighAltitudeSnow(BlockPos pos, CallbackInfoReturnable<Biome.Precipitation> cir) {
         if (!this.hasPrecipitation()) {
             cir.setReturnValue(Biome.Precipitation.NONE);
             return;

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/world/TerrainDiffusionBiomeSource.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/world/TerrainDiffusionBiomeSource.java
@@ -16,7 +16,6 @@ import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.random.Random;
-import net.minecraft.world.WorldView;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.BiomeKeys;
 import net.minecraft.world.biome.source.BiomeCoords;
@@ -117,11 +116,6 @@ public class TerrainDiffusionBiomeSource extends BiomeSource {
         }
 
         return defaultEntry;
-    }
-
-    @Override
-    public Pair<BlockPos, RegistryEntry<Biome>> locateBiome(BlockPos origin, int radius, int horizontalBlockCheckInterval, int verticalBlockCheckInterval, Predicate<RegistryEntry<Biome>> predicate, MultiNoiseUtil.MultiNoiseSampler noiseSampler, WorldView world) {
-        return null;
     }
 
     @Override


### PR DESCRIPTION
## Summary

- Bump versions in gradle.properties to MC 1.21.1: minecraft_version=1.21.1, yarn_mappings=1.21.1+build.3, loader_version=0.16.9, fabric_version=0.116.11+1.21.1
- Fix ClickEvent.OpenUrl in TerrainDiffusionMc.java — the ClickEvent.OpenUrl(URI) subclass was added after 1.21.1; reverted to new ClickEvent(ClickEvent.Action.OPEN_URL, url)
- Fix BiomeMixin — Biome.getPrecipitation only took BlockPos in 1.21.1; removed the extra int seaLevel parameter added in a later version
- Remove locateBiome(BlockPos,...,WorldView) override — that signature did not exist in BiomeSource until after 1.21.1

## Reviewer notes

CreateWorldScreenWorldTabMixin uses intermediary names (field_42182, method_48676, method_48680, method_48681) valid for MC 1.21.11. These must be verified against 1.21.1 Yarn mappings before the client mixin compiles cleanly. Run ./gradlew genSources and inspect CreateWorldScreen$WorldTab, or check https://github.com/FabricMC/yarn/tree/1.21.1+build.3

Also verify yarn_mappings=1.21.1+build.3 is the latest build at https://fabricmc.net/develop/

## Runtime setup (NeoForge side)

Users install alongside the mod jar:
- NeoForge 21.1.221
- Connector 2.0.0-beta.14+1.21.1
- Forgified Fabric API 0.116.7+2.2.4+1.21.1