### PR TITLE
Add CoreML GPU support for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Three builds are available on the [Releases](https://github.com/xandergos/terrai
 | ------------------------- | --------------------------- | --------------------------------------- |
 | **Windows** (recommended) | Windows with any modern GPU | None                                    |
 | **CUDA**                  | NVIDIA GPUs                 | [CUDA + cuDNN install](CUDA_INSTALL.md) |
+| **Mac**                   | Apple Silicon               | None                                    |
 | **CPU (Slow)**            | Everything                  | None                                    |
 
 
@@ -112,6 +113,11 @@ Build for CUDA:
 Build for CPU:
 ```
 ./gradlew build -PuseCpu=true
+```
+
+Build for macOS (CoreML):
+```
+./gradlew build -PuseCoreml=true
 ```
 
 Build all:

--- a/build.gradle
+++ b/build.gradle
@@ -9,21 +9,22 @@ import java.security.MessageDigest
 
 def useCuda = project.hasProperty('useCuda') && project.property('useCuda').toString().toLowerCase() == 'true'
 def useDml = project.hasProperty('useDml') && project.property('useDml').toString().toLowerCase() == 'true'
+def useCoreml = project.hasProperty('useCoreml') && project.property('useCoreml').toString().toLowerCase() == 'true'
 def useCpu = project.hasProperty('useCpu') && project.property('useCpu').toString().toLowerCase() == 'true'
 def withSourcesJar = project.hasProperty('withSourcesJar') && project.property('withSourcesJar').toString().toLowerCase() == 'true'
 
-if ([useCuda, useDml, useCpu].count { it } > 1) {
-    throw new GradleException("Only one of -PuseCuda, -PuseDml, or -PuseCpu may be specified at a time.")
+if ([useCuda, useDml, useCoreml, useCpu].count { it } > 1) {
+    throw new GradleException("Only one of -PuseCuda, -PuseDml, -PuseCoreml, or -PuseCpu may be specified at a time.")
 }
-if (!useDml && !useCpu && !useCuda) useDml = true
+if (!useDml && !useCpu && !useCuda && !useCoreml) useDml = true
 
-println "Build variant: ${useCuda ? 'CUDA' : useDml ? 'DirectML (Windows)' : 'CPU'}"
+println "Build variant: ${useCuda ? 'CUDA' : useDml ? 'DirectML (Windows)' : useCoreml ? 'CoreML (macOS)' : 'CPU'}"
 def modelRepositorySlug = 'xandergos/terrain-diffusion-30m-onnx'
 def modelRepositoryRevision = 'ad2df557eca5645f588766101cf3bc3682455c3e'
 def generatedManifestDirectory = layout.buildDirectory.dir('generated/model-assets').get().asFile
 def generatedManifestFile = new File(generatedManifestDirectory, 'model-assets-manifest.json')
 
-def buildVariant = useCuda ? 'cuda' : useDml ? 'windows' : 'cpu'
+def buildVariant = useCuda ? 'cuda' : useDml ? 'windows' : useCoreml ? 'mac' : 'cpu'
 version = "${project.mod_version}-${buildVariant}+${project.minecraft_version}"
 group = project.maven_group
 
@@ -74,7 +75,7 @@ dependencies {
     if (useCuda) {
         implementation "com.microsoft.onnxruntime:onnxruntime_gpu:1.20.0"
         include "com.microsoft.onnxruntime:onnxruntime_gpu:1.20.0"
-    } else if (useCpu) {
+    } else if (useCoreml || useCpu) {
         implementation "com.microsoft.onnxruntime:onnxruntime:1.20.0"
         include "com.microsoft.onnxruntime:onnxruntime:1.20.0"
     } else if (useDml) {
@@ -221,7 +222,7 @@ tasks.register('generateModelAssetManifest') {
 def isWindows = System.getProperty('os.name').toLowerCase().startsWith('windows')
 def gradlewExecutable = rootProject.file(isWindows ? 'gradlew.bat' : 'gradlew').absolutePath
 
-['Cuda', 'Dml', 'Cpu'].each { variant ->
+['Cuda', 'Dml', 'Coreml', 'Cpu'].each { variant ->
     tasks.register("build${variant}", Exec) {
         workingDir rootProject.projectDir
         commandLine gradlewExecutable, 'build', "-Puse${variant}=true"
@@ -229,7 +230,7 @@ def gradlewExecutable = rootProject.file(isWindows ? 'gradlew.bat' : 'gradlew').
 }
 
 tasks.register('buildAll') {
-    dependsOn 'buildCuda', 'buildDml', 'buildCpu'
+    dependsOn 'buildCuda', 'buildDml', 'buildCoreml', 'buildCpu'
 }
 
 String sha256Hex(byte[] fileBytes) {

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/pipeline/OnnxModel.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/pipeline/OnnxModel.java
@@ -1,6 +1,7 @@
 package com.github.xandergos.terraindiffusionmc.pipeline;
 
 import ai.onnxruntime.*;
+import ai.onnxruntime.providers.CoreMLFlags;
 import ai.onnxruntime.providers.OrtCUDAProviderOptions;
 import com.github.xandergos.terraindiffusionmc.config.TerrainDiffusionConfig;
 import org.slf4j.Logger;
@@ -12,6 +13,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -31,6 +33,7 @@ public final class OnnxModel implements AutoCloseable {
 
     private static volatile String resolvedInferenceProvider = null;
     private static final AtomicBoolean providerLoggedOnce = new AtomicBoolean(false);
+    private static final AtomicBoolean coremlWarnLoggedOnce = new AtomicBoolean(false);
     private static final AtomicBoolean cudaWarnLoggedOnce = new AtomicBoolean(false);
     private static final AtomicBoolean dmlWarnLoggedOnce = new AtomicBoolean(false);
     private static final AtomicBoolean noGpuWarnLoggedOnce = new AtomicBoolean(false);
@@ -321,10 +324,25 @@ public final class OnnxModel implements AutoCloseable {
                 }
             }
         }
+
+        if (!added) {
+            try {
+                // ENABLE_ON_SUBGRAPH: allow CoreML to handle partial graphs with CPU fallback
+                // for unsupported ops, maximising GPU utilisation without requiring full-graph support.
+                opts.addCoreML(EnumSet.of(CoreMLFlags.ENABLE_ON_SUBGRAPH));
+                added = true;
+                setResolvedProviderOnce("CoreML");
+            } catch (Throwable t) {
+                if (coremlWarnLoggedOnce.compareAndSet(false, true)) {
+                    LOG.warn("CoreML not available: {} - {}. This is expected if you are not using a CoreML build.",
+                            t.getClass().getSimpleName(), t.getMessage());
+                }
+            }
+        }
         if (gpuRequired && !added) {
             throw new OrtException(
-                    "inference.device=gpu but neither CUDA nor DirectML is available. " +
-                    "Use the GPU build or set inference.device=cpu.");
+                    "inference.device=gpu but no GPU provider (CUDA, DirectML, CoreML) is available. " +
+                    "Use the appropriate build for your platform or set inference.device=cpu.");
         }
         if (!added) {
             setResolvedProviderOnce("CPU");

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/pipeline/OnnxModel.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/pipeline/OnnxModel.java
@@ -161,6 +161,11 @@ public final class OnnxModel implements AutoCloseable {
             OrtSession.SessionOptions sessionOptions = new OrtSession.SessionOptions();
             sessionOptions.setOptimizationLevel(OrtSession.SessionOptions.OptLevel.ALL_OPT);
             addGpuProvider(sessionOptions);
+            if ("CoreML".equals(resolvedInferenceProvider)) {
+                throw new OrtException(
+                        "inference.offload_models=false is not supported with CoreML. " +
+                        "Set inference.offload_models=true in terrain-diffusion-mc.properties.");
+            }
             this.gpuSession = env.createSession(modelBytes, sessionOptions);
             this.cpuSession = null;
             LOG.info("ONNX model '{}' loaded on GPU ({} KB) in {} ms",


### PR DESCRIPTION
Adds a CoreML build variant (`-PuseCoreml=true`) that uses ONNX Runtime's CoreML execution provider for hardware-accelerated inference on Apple Silicon, following the same pattern as the existing CUDA, DirectML, and CPU variants.

## Changes

- `build.gradle`: adds `useCoreml` flag: selects `onnxruntime` (standard package, includes CoreML) and adds `buildCoreml` task and includes it in `buildAll`
- `OnnxModel.java`: CoreML attempted with `ENABLE_ON_SUBGRAPH` (allows CoreML to handle partial graphs with CPU fallback for unsupported ops)
- `README.md`: adds Mac build to the variant table and build instructions

## Usage

```
./gradlew build -PuseCoreml=true
```

## Test environment

Minecraft 1.21.11, macOS 26.4.1 on M4 Pro, tested across several worlds with `offload_models=true`. CoreML sessions load correctly and inference runs on Apple Silicon GPU. Terrain generates correctly (though spawn seems to be systematically in oceans, which appears to be a separate upstream issue).

## Know limitation

`offload_models=false` causes an Espresso error (-1) usually after a few minutes due to concurrent ANE contention between the 3 simultaneous CoreML sessions. A proper fix would involve catching the GPU inference error in `runWithSession()` and recreating a fresh session before retrying (see #59). This would affect the general code path shared with CUDA and DirectML.