### PR TITLE
perf: improved performance for chunk generation after tile is cached

### DIFF
--- a/src/main/java/com/github/xandergos/terraindiffusionmc/pipeline/LocalTerrainProvider.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/pipeline/LocalTerrainProvider.java
@@ -9,12 +9,14 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Random;
+import java.util.Comparator;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Provides terrain heightmap and biome data from the local WorldPipeline.
@@ -56,10 +58,14 @@ public final class LocalTerrainProvider {
         }
     }
 
+    private static record CacheKey(int i1, int j1, int i2, int j2) {}
+    private static record CacheEntry(HeightmapData data, AtomicLong lastAccessed) {}
+
     private static final int MAX_CACHE_SIZE = 64;
-    private static final Object CACHE_LOCK = new Object();
-    private static final Map<String, HeightmapData> CACHE = new LinkedHashMap<>(16, 0.75f, true);
-    private static final Map<String, Future<HeightmapData>> PENDING = new ConcurrentHashMap<>();
+    private static final int MAX_CACHE_SIZE_HEADROOM = 8;
+    private static final Map<CacheKey, CacheEntry> CACHE = new ConcurrentHashMap<>();
+    private static final AtomicLong CACHE_CLOCK = new AtomicLong();
+    private static final Map<CacheKey, Future<HeightmapData>> PENDING = new ConcurrentHashMap<>();
     /** Single thread for pipeline.get() so MemoryTileStore is not accessed concurrently. */
     private static final ExecutorService INFERENCE_EXECUTOR = Executors.newSingleThreadExecutor(r -> {
         Thread t = new Thread(r, "terrain-diffusion-inference");
@@ -71,6 +77,8 @@ public final class LocalTerrainProvider {
     private static long instanceSeed;
 
     private final WorldPipeline pipeline;
+
+    private static final Object INIT_LOCK = new Object();
 
     private LocalTerrainProvider(long seed, PipelineModels models) {
         this.pipeline = new WorldPipeline(seed, models);
@@ -87,26 +95,28 @@ public final class LocalTerrainProvider {
         } else if (instanceSeed != seed) {
             INSTANCE.pipeline.setSeed(seed);
             instanceSeed = seed;
-            synchronized (CACHE_LOCK) { CACHE.clear(); }
+            CACHE.clear();
             PENDING.clear();
         }
     }
 
-    public static synchronized LocalTerrainProvider getInstance() {
-        if (INSTANCE == null) {
+    public static LocalTerrainProvider getInstance() {
+        if (INSTANCE != null) return INSTANCE;
+
+        synchronized(INIT_LOCK) {
+            if (INSTANCE != null) return INSTANCE;
             PipelineModels.awaitLoad();
             PipelineModels models = PipelineModels.getInstance();
             if (models == null) throw new IllegalStateException("PipelineModels failed to load");
             INSTANCE = new LocalTerrainProvider(0L, models);
             instanceSeed = 0L;
         }
+
         return INSTANCE;
     }
 
     public static void clearCache() {
-        synchronized (CACHE_LOCK) {
-            CACHE.clear();
-        }
+        CACHE.clear();
         PENDING.clear();
     }
 
@@ -147,7 +157,7 @@ public final class LocalTerrainProvider {
             LocalTerrainProvider provider = getInstance();
             provider.pipeline.setSeed(newSeed);
             instanceSeed = newSeed;
-            synchronized (CACHE_LOCK) { CACHE.clear(); }
+            CACHE.clear();
             PENDING.clear();
             return null;
         });
@@ -171,12 +181,17 @@ public final class LocalTerrainProvider {
      * If the caller is the server or a chunk worker, the game will stall until this returns.
      */
     public HeightmapData fetchHeightmap(int i1, int j1, int i2, int j2) {
-        String key = i1 + "," + j1 + "," + i2 + "," + j2;
-        synchronized (CACHE_LOCK) {
-            HeightmapData cached = CACHE.get(key);
-            if (cached != null) return cached;
+        CacheKey key = new CacheKey(i1, j1, i2, j2);
+        CacheEntry cached = CACHE.get(key);
+        if (cached != null) {
+            cached.lastAccessed.set(CACHE_CLOCK.incrementAndGet());
+            return cached.data;
         }
 
+        return this.genHeightmap(key, i1, j1, i2, j2);
+    }
+
+    private HeightmapData genHeightmap(CacheKey key, int i1, int j1, int i2, int j2) {
         int scale = WorldScaleManager.getCurrentScale();
         FutureTask<HeightmapData> task = new FutureTask<>(() -> {
             long computedWindowCountBefore = pipeline.getTotalComputedWindowCount();
@@ -191,10 +206,8 @@ public final class LocalTerrainProvider {
             LOG.info(
                     "Terrain Diffusion ({}) finished generating region {}x{} ({} newly computed windows)",
                     OnnxModel.getResolvedInferenceProvider(), regionWidth, regionHeight, newlyComputedWindowCount);
-            synchronized (CACHE_LOCK) {
-                CACHE.put(key, data);
-                evictLruTo(MAX_CACHE_SIZE);
-            }
+            CACHE.put(key, new CacheEntry(data, new AtomicLong(CACHE_CLOCK.incrementAndGet())));
+            evictLruTo(MAX_CACHE_SIZE);
             PENDING.remove(key);
             return data;
         });
@@ -217,10 +230,13 @@ public final class LocalTerrainProvider {
     }
 
     private static void evictLruTo(int maxSize) {
-        Iterator<Map.Entry<String, HeightmapData>> it = CACHE.entrySet().iterator();
-        while (CACHE.size() > maxSize && it.hasNext()) {
-            it.next();
-            it.remove();
+        int headroomHalf = MAX_CACHE_SIZE_HEADROOM / 2;
+        if (CACHE.size() > maxSize + headroomHalf) {
+            CACHE.entrySet().stream()
+                .sorted(Comparator.comparingLong(e -> e.getValue().lastAccessed.get()))
+                .limit(MAX_CACHE_SIZE_HEADROOM)
+                .map(Map.Entry::getKey)
+                .forEach(CACHE::remove);
         }
     }
 

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/world/TerrainDiffusionDensityFunction.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/world/TerrainDiffusionDensityFunction.java
@@ -46,9 +46,63 @@ public class TerrainDiffusionDensityFunction implements DensityFunction {
         return targetHeight - y;
     }
 
+    private static final class FillContext {
+        int blockStartX, blockStartZ, blockEndX, blockEndZ;
+        HeightmapData data;
+
+        void update(int x, int z) {
+            if (x < blockStartX || x >= blockEndX) this.init(x, z);
+            if (z < blockStartZ || z >= blockEndZ) this.init(x, z);
+        }
+
+        void init(int x, int z) {
+            int tileSize = TerrainDiffusionConfig.tileSize();
+            int tileShift = Integer.numberOfTrailingZeros(tileSize);
+
+            int tileX = x >> tileShift;
+            int tileZ = z >> tileShift;
+
+            this.blockStartX = tileX << tileShift;
+            this.blockStartZ = tileZ << tileShift;
+            this.blockEndX = blockStartX + tileSize;
+            this.blockEndZ = blockStartZ + tileSize;
+
+            this.data = LocalTerrainProvider.getInstance()
+                .fetchHeightmap(blockStartZ, blockStartX, blockEndZ, blockEndX);
+        }
+    }
+
     @Override
     public void fill(double[] densities, DensityFunction.EachApplier applier) {
-        applier.fill(densities, this);
+        if (densities.length == 0) return;
+
+        FillContext ctx = new FillContext();
+        DensityFunction.NoisePos pos = applier.at(0);
+        int x = pos.blockX();
+        int z = pos.blockZ();
+        int y = pos.blockY();
+        ctx.init(x, z);
+
+        for (int i = 0; i < densities.length; i++) {
+            pos = applier.at(i);
+            x = pos.blockX();
+            z = pos.blockZ();
+            y = pos.blockY();
+            ctx.update(x, z);
+
+            HeightmapData data = ctx.data;
+            if (data == null || data.heightmap == null) {
+                densities[i] = -y;
+                continue;
+            }
+
+            int localX = Math.max(0, Math.min(data.width  - 1, x - ctx.blockStartX));
+            int localZ = Math.max(0, Math.min(data.height - 1, z - ctx.blockStartZ));
+
+            int targetHeight = HeightConverter
+                .convertToMinecraftHeight(data.heightmap[localZ][localX]);
+            densities[i] = targetHeight - y;
+        }
     }
 
     @Override


### PR DESCRIPTION
bring chunk generation speed on par with vanilla

using distant horizon with 32 threads, 1024 view distance(just big enough to run to stabilize)

some data:

terrain diffusion(scale 6), release [2.1.0](https://github.com/xandergos/terrain-diffusion-mc/releases/tag/v2.1.0):
<img width="3840" height="2071" alt="td-dh-scale6-2_1_0" src="https://github.com/user-attachments/assets/93b08f84-abaa-44e3-b205-a3bf8e665997" />

terrain diffusion(scale 6):
<img width="3833" height="1775" alt="td-dh-scale6" src="https://github.com/user-attachments/assets/01fc9bdc-a3a0-40a6-b2cc-07d05a978333" />

terrain diffusion(scale 1):
<img width="3833" height="1775" alt="td-dh-scale1" src="https://github.com/user-attachments/assets/fb0efbfb-5e8e-43e1-a2f1-1b3687444d4f" />

vanilla AMPLIFIED:
<img width="3833" height="1775" alt="vanilla-dh-amplified" src="https://github.com/user-attachments/assets/16f73fb3-619b-4232-8843-9c2faf3bae37" />

vanilla default:
<img width="3833" height="1775" alt="vanilla-dh-default" src="https://github.com/user-attachments/assets/f1b333ee-2b08-46fa-a59d-80495a6360f4" />

using directml build(doesn't want to mess around with my cuda env, it's cuda 13), 
with 2070 8GB + 5950x

also, you may want make max cache size configurable, as some generation pattern that isn't batched by region(like distant horizon one), can easily eat up 300 cache entry before it circle back(at this scale)