### PR TITLE
Fix spawning issues

### DIFF
--- a/CUDA_INSTALL.md
+++ b/CUDA_INSTALL.md
@@ -2,8 +2,6 @@
 
 This guide is only needed for the `-cuda` build of Terrain Diffusion MC. If you downloaded the `-windows` build, no setup is required.
 
-> **On Linux?** Follow the [Official ONNX Runtime instructions](https://onnxruntime.ai/docs/install/#cuda-and-cudnn). The required CUDA and cuDNN versions are the same as below.
-
 ## Installation Steps (Windows)
 
 #### Step 1: Install CUDA 12
@@ -39,6 +37,123 @@ Find the cuDNN folder containing `cudnn64_9.dll`. It should look something like 
 #### Step 5: Restart your PC
 
 You may need to restart your PC for PATH changes to take effect. Once you're back, you're all set.
+
+
+---
+
+## Linux
+
+The mod requires **CUDA 12.x** and **cuDNN 9.x**. The approach differs depending on your distro.
+
+> ⚠️ **Do not install CUDA 13** — it is not supported yet. If `nvidia-smi` shows "CUDA Version: 13.x", that is just your driver's maximum supported version, not an installed toolkit. You still need to install CUDA 12.x separately.
+
+### Option A: Ubuntu / Debian (Recommended)
+
+This is the simplest path. NVIDIA provides native `.deb` packages.
+
+#### Step 1: Install CUDA 12
+
+Go to the [CUDA Toolkit Archive](https://developer.nvidia.com/cuda-toolkit-archive), select your Ubuntu version, and follow the `deb (network)` instructions. Make sure you pick a **12.x** version.
+
+#### Step 2: Install cuDNN 9
+
+Go to the [cuDNN download page](https://developer.nvidia.com/cudnn-downloads), select:
+- Linux → x86_64 → Ubuntu → your version → **Deb**
+- Select **CUDA 12** and download
+
+Install with:
+```bash
+sudo dpkg -i cudnn-local-repo-*.deb
+sudo apt-get update
+sudo apt-get install libcudnn9-cuda-12
+```
+#### Step 3: Set LD_LIBRARY_PATH
+
+Before launching Minecraft, set the library path in your terminal:
+
+```bash
+export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu
+```
+
+Then launch your Minecraft launcher from the same terminal session.
+
+> **Prism Launcher / MultiMC users:** You can set this per-instance instead. Go to instance → **Edit** → **Settings** → **Environment Variables** and add `LD_LIBRARY_PATH` = `/usr/lib/x86_64-linux-gnu`. This way you don't need the terminal export every time.
+
+Launch the game. Done.
+
+---
+
+### Option B: Arch Linux (and Arch-based distros like EndeavourOS, Manjaro)
+
+Arch does not package CUDA 12.x and 13.x separately in the official repos, so the cleanest approach for users who need to keep another CUDA version is to install CUDA 12.x via the `.run` file into an isolated directory.
+
+#### Step 1: Download CUDA 12.x runfile
+
+Go to the [CUDA Toolkit Archive](https://developer.nvidia.com/cuda-toolkit-archive) and download any distro's **12.x** version as a **Linux runfile (local)**. CUDA 12.0 is known to work.
+
+#### Step 2: Install CUDA 12 into an isolated directory
+
+> ℹ️ This does **not** touch your existing CUDA installation or GPU drivers.
+
+Arch's libxml2 ships under a different versioned name than the runfile expects. Create a symlink first:
+```bash
+sudo ln -s /usr/lib/libxml2.so /usr/lib/libxml2.so.2
+```
+
+Then install:
+```bash
+sudo LD_LIBRARY_PATH=/usr/lib:$LD_LIBRARY_PATH sh cuda_12.x.x_*.run \
+  --silent \
+  --toolkit \
+  --toolkitpath=/usr/local/cuda-12.0 \
+  --no-opengl-libs \
+  --override
+```
+
+The `--override` flag bypasses a gcc version check that fails on Arch. The three "no version information available" warnings that appear are harmless.
+
+Verify it worked:
+```bash
+ls /usr/local/cuda-12.0/lib64/libcudart.so*
+# Should show: libcudart.so.12
+```
+
+#### Step 3: Download and install cuDNN 9.x
+
+Go to the [cuDNN download page](https://developer.nvidia.com/cudnn-downloads) and select:
+- Linux → x86_64 → **Tarball** → **CUDA 12** → **Full**
+
+> ⚠️ Make sure you select **CUDA 12**, not CUDA 13. The filename should contain `cuda12`.
+
+Extract and copy into your CUDA 12 directory:
+```bash
+tar -xf cudnn-linux-x86_64-9.*.tar.xz
+sudo cp cudnn-linux-x86_64-9.*_cuda12-archive/include/cudnn*.h /usr/local/cuda-12.0/include/
+sudo cp -P cudnn-linux-x86_64-9.*_cuda12-archive/lib/libcudnn* /usr/local/cuda-12.0/lib64/
+sudo chmod a+r /usr/local/cuda-12.0/lib64/libcudnn*
+```
+
+Verify:
+```bash
+ls /usr/local/cuda-12.0/lib64/libcudnn.so*
+# Should show: libcudnn.so.9
+```
+
+#### Step 4: Set LD_LIBRARY_PATH
+
+Before launching Minecraft, set the library path in your terminal:
+
+```bash
+export LD_LIBRARY_PATH=/usr/local/cuda-12.0/lib64
+```
+
+Then launch your Minecraft launcher from the same terminal session.
+
+> **Prism Launcher / MultiMC users:** You can set this per-instance instead. Go to instance → **Edit** → **Settings** → **Environment Variables** and add `LD_LIBRARY_PATH` = `/usr/local/cuda-12.0/lib64`. This tells the JVM exactly where to find the CUDA and cuDNN libraries without affecting anything else on your system.
+
+Launch the game. Done.
+
+---
 
 ## Troubleshooting
 

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/mixin/MinecraftServerMixin.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/mixin/MinecraftServerMixin.java
@@ -1,0 +1,47 @@
+package com.github.xandergos.terraindiffusionmc.mixin;
+
+import com.github.xandergos.terraindiffusionmc.world.SpawnSelector;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.SpawnLocating;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.WorldProperties.SpawnPoint;
+import net.minecraft.world.level.ServerWorldProperties;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MinecraftServer.class)
+public class MinecraftServerMixin {
+
+    @Inject(method = "setupSpawn", at = @At("HEAD"), cancellable = true)
+    private void overrideWorldSpawn(ServerWorld world, ServerWorldProperties worldProperties, boolean bonusChest, boolean debugWorld, CallbackInfo ci) {
+        // Ensure this only runs for the Overworld
+        if (world.getRegistryKey() != net.minecraft.world.World.OVERWORLD) {
+            return;
+        }
+
+        // Calculate your target coordinates
+        // This method must block until the terrain model returns the desired X/Z.
+        ChunkPos targetChunk = SpawnSelector.calculateCoarseSpawnChunk();
+
+        int targetX = targetChunk.getCenterX();
+        int targetZ = targetChunk.getCenterZ();
+
+        // Use Vanilla logic to find a safe block within that area
+        BlockPos safeSpawnPos = SpawnLocating.findServerSpawnPoint(world, new ChunkPos(targetChunk.x, targetChunk.z));
+
+        // Fallback if no safe block is found (e.g., entirely ocean)
+        if (safeSpawnPos == null) {
+            // Find the highest block at the exact target X/Z as a fallback
+            int fallbackY = world.getChunkManager().getChunkGenerator().getHeight(targetX, targetZ, net.minecraft.world.Heightmap.Type.MOTION_BLOCKING, world, null);
+            safeSpawnPos = new BlockPos(targetX, fallbackY, targetZ);
+        }
+
+        worldProperties.setSpawnPoint(SpawnPoint.create(world.getRegistryKey(), safeSpawnPos, 0.0F, 0.0F));
+
+        ci.cancel();
+    }
+}

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/mixin/MinecraftServerMixin.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/mixin/MinecraftServerMixin.java
@@ -3,6 +3,7 @@ package com.github.xandergos.terraindiffusionmc.mixin;
 import com.github.xandergos.terraindiffusionmc.world.SpawnSelector;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.world.World;
 import net.minecraft.world.WorldProperties.SpawnPoint;
 import net.minecraft.world.chunk.ChunkLoadProgress;
 import net.minecraft.world.level.ServerWorldProperties;
@@ -17,7 +18,7 @@ public class MinecraftServerMixin {
     @Inject(method = "setupSpawn", at = @At("HEAD"), cancellable = true)
     private static void overrideWorldSpawn(ServerWorld world, ServerWorldProperties worldProperties, boolean bonusChest, boolean debugWorld, ChunkLoadProgress loadProgress, CallbackInfo ci) {
         // Ensure this only runs for the Overworld
-        if (world.getRegistryKey() != net.minecraft.world.World.OVERWORLD) {
+        if (!world.getRegistryKey().equals(World.OVERWORLD)) {
             return;
         }
 

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/mixin/MinecraftServerMixin.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/mixin/MinecraftServerMixin.java
@@ -2,14 +2,10 @@ package com.github.xandergos.terraindiffusionmc.mixin;
 
 import com.github.xandergos.terraindiffusionmc.world.SpawnSelector;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.network.SpawnLocating;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.WorldProperties.SpawnPoint;
 import net.minecraft.world.chunk.ChunkLoadProgress;
 import net.minecraft.world.level.ServerWorldProperties;
-import net.minecraft.world.Heightmap;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -25,23 +21,9 @@ public class MinecraftServerMixin {
             return;
         }
 
-        // Calculate your target coordinates
-        // This method must block until the terrain model returns the desired X/Z.
-        ChunkPos targetChunk = SpawnSelector.calculateCoarseSpawnChunk();
+        SpawnPoint spawnPoint = SpawnSelector.findSpawnPoint(world);
 
-        int targetX = targetChunk.getCenterX();
-        int targetZ = targetChunk.getCenterZ();
-
-        // Use Vanilla logic to find a safe block within that area
-        BlockPos safeSpawnPos = SpawnLocating.findServerSpawnPoint(world, new ChunkPos(targetChunk.x, targetChunk.z));
-
-        // Fallback to middle of the block if finding a saf spawn position fails.
-        if (safeSpawnPos == null) {
-            int spawnY = world.getTopY(Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, targetX, targetZ);
-            safeSpawnPos = new BlockPos(targetX, spawnY, targetZ);
-        }
-
-        worldProperties.setSpawnPoint(SpawnPoint.create(world.getRegistryKey(), safeSpawnPos, 0.0F, 0.0F));
+        worldProperties.setSpawnPoint(spawnPoint);
         ci.cancel();
     }
 }

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/mixin/MinecraftServerMixin.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/mixin/MinecraftServerMixin.java
@@ -27,7 +27,7 @@ public class MinecraftServerMixin {
 
         // Calculate your target coordinates
         // This method must block until the terrain model returns the desired X/Z.
-        ChunkPos targetChunk = SpawnSelector.calculateCoarseSpawnChunk(world);
+        ChunkPos targetChunk = SpawnSelector.calculateCoarseSpawnChunk();
 
         int targetX = targetChunk.getCenterX();
         int targetZ = targetChunk.getCenterZ();

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/mixin/MinecraftServerMixin.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/mixin/MinecraftServerMixin.java
@@ -9,6 +9,7 @@ import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.WorldProperties.SpawnPoint;
 import net.minecraft.world.chunk.ChunkLoadProgress;
 import net.minecraft.world.level.ServerWorldProperties;
+import net.minecraft.world.Heightmap;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -26,7 +27,7 @@ public class MinecraftServerMixin {
 
         // Calculate your target coordinates
         // This method must block until the terrain model returns the desired X/Z.
-        ChunkPos targetChunk = SpawnSelector.calculateCoarseSpawnChunk();
+        ChunkPos targetChunk = SpawnSelector.calculateCoarseSpawnChunk(world);
 
         int targetX = targetChunk.getCenterX();
         int targetZ = targetChunk.getCenterZ();
@@ -34,8 +35,11 @@ public class MinecraftServerMixin {
         // Use Vanilla logic to find a safe block within that area
         BlockPos safeSpawnPos = SpawnLocating.findServerSpawnPoint(world, new ChunkPos(targetChunk.x, targetChunk.z));
 
-        int spawnY = world.getTopY(net.minecraft.world.Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, targetX, targetZ);
-        safeSpawnPos = new BlockPos(targetX, spawnY, targetZ);
+        // Fallback to middle of the block if finding a saf spawn position fails.
+        if (safeSpawnPos == null) {
+            int spawnY = world.getTopY(Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, targetX, targetZ);
+            safeSpawnPos = new BlockPos(targetX, spawnY, targetZ);
+        }
 
         worldProperties.setSpawnPoint(SpawnPoint.create(world.getRegistryKey(), safeSpawnPos, 0.0F, 0.0F));
         ci.cancel();

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/mixin/MinecraftServerMixin.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/mixin/MinecraftServerMixin.java
@@ -7,6 +7,7 @@ import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.WorldProperties.SpawnPoint;
+import net.minecraft.world.chunk.ChunkLoadProgress;
 import net.minecraft.world.level.ServerWorldProperties;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -17,7 +18,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class MinecraftServerMixin {
 
     @Inject(method = "setupSpawn", at = @At("HEAD"), cancellable = true)
-    private void overrideWorldSpawn(ServerWorld world, ServerWorldProperties worldProperties, boolean bonusChest, boolean debugWorld, CallbackInfo ci) {
+    private static void overrideWorldSpawn(ServerWorld world, ServerWorldProperties worldProperties, boolean bonusChest, boolean debugWorld, ChunkLoadProgress loadProgress, CallbackInfo ci) {
         // Ensure this only runs for the Overworld
         if (world.getRegistryKey() != net.minecraft.world.World.OVERWORLD) {
             return;
@@ -33,15 +34,10 @@ public class MinecraftServerMixin {
         // Use Vanilla logic to find a safe block within that area
         BlockPos safeSpawnPos = SpawnLocating.findServerSpawnPoint(world, new ChunkPos(targetChunk.x, targetChunk.z));
 
-        // Fallback if no safe block is found (e.g., entirely ocean)
-        if (safeSpawnPos == null) {
-            // Find the highest block at the exact target X/Z as a fallback
-            int fallbackY = world.getChunkManager().getChunkGenerator().getHeight(targetX, targetZ, net.minecraft.world.Heightmap.Type.MOTION_BLOCKING, world, null);
-            safeSpawnPos = new BlockPos(targetX, fallbackY, targetZ);
-        }
+        int spawnY = world.getTopY(net.minecraft.world.Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, targetX, targetZ);
+        safeSpawnPos = new BlockPos(targetX, spawnY, targetZ);
 
         worldProperties.setSpawnPoint(SpawnPoint.create(world.getRegistryKey(), safeSpawnPos, 0.0F, 0.0F));
-
         ci.cancel();
     }
 }

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/world/SpawnSelector.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/world/SpawnSelector.java
@@ -32,45 +32,60 @@ public final class SpawnSelector {
     }
 
     public static SpawnPoint findSpawnPoint(ServerWorld world) {
-        final TileSample coarseTile = calculateCoarseSpawnChunk();
+        final CoarseSample coarseSample = calculateCoarseSpawnChunk();
 
         // If no valid spawn found, default to origin.
-        if (!coarseTile.hasSample()) {
+        if (coarseSample == null) {
             LOG.warn("SpawnSelector: no valid coarse spawn found; defaulting to origin");
             return SpawnPoint.create(world.getRegistryKey(), BlockPos.ORIGIN, 0.0F, 0.0F);
         }
 
         // Refine the coarse tile to find a safe spawn position.
-        BlockPos safeSpawnPos = findSafeSpawn(world, coarseTile);
+        final BlockPos safeSpawnPos = findSafeSpawn(world, coarseSample);
 
         return SpawnPoint.create(world.getRegistryKey(), safeSpawnPos, 0.0F, 0.0F);
     }
 
-    private static TileSample calculateCoarseSpawnChunk() {
+    private static CoarseSample calculateCoarseSpawnChunk() {
         final int half = COARSE_GRID_SIZE / 2;
-        final TileSample tile = new TileSample();
+        final int sampleSpacing = COARSE_GRID_SPACING + 1;
+        final int ciMin = -half * sampleSpacing;
+        final int cjMin = -half * sampleSpacing;
+        final int ciMaxExclusive = (half + 1) * sampleSpacing;
+        final int cjMaxExclusive = (half + 1) * sampleSpacing;
 
         try {
             LOG.debug("SpawnSelector: starting coarse sampling for Overworld");
+            final FloatTensor coarseSlice = LocalTerrainProvider.getPipelineCoarse(ciMin, cjMin, ciMaxExclusive, cjMaxExclusive);
 
             // Expand in square "rings" around (0, 0) in grid coordinates.
             // r is the ring radius in grid coordinates.
             for (int r = 0; r <= half; r++) {
                 for (int x = -r; x <= r; x++) {
-                    if (sampleTile(x, -r, tile)) {
-                        return tile;
+                    // Top edge
+                    final CoarseSample topSample = sampleTile(coarseSlice, x, -r, sampleSpacing, ciMin, cjMin);
+                    if (topSample != null) {
+                        return topSample;
                     }
-                    if (r != 0 && sampleTile(x, r, tile)) {
-                        return tile;
+                    // Bottom edge
+                    if (r != 0) {
+                        final CoarseSample bottomSample = sampleTile(coarseSlice, x, r, sampleSpacing, ciMin, cjMin);
+                        if (bottomSample != null) {
+                            return bottomSample;
+                        }
                     }
                 }
                 if (r > 0) {
                     for (int z = -r + 1; z <= r - 1; z++) {
-                        if (sampleTile(-r, z, tile)) {
-                            return tile;
+                        // Left edge
+                        final CoarseSample leftSample = sampleTile(coarseSlice, -r, z, sampleSpacing, ciMin, cjMin);
+                        if (leftSample != null) {
+                            return leftSample;
                         }
-                        if (sampleTile(r, z, tile)) {
-                            return tile;
+                        // Right edge
+                        final CoarseSample rightSample = sampleTile(coarseSlice, r, z, sampleSpacing, ciMin, cjMin);
+                        if (rightSample != null) {
+                            return rightSample;
                         }
                     }
                 }
@@ -79,8 +94,8 @@ public final class SpawnSelector {
             LOG.error("SpawnSelector: unexpected error", e);
         }
 
-        // No valid spawn found; return an invalid sample.
-        return tile;
+        // No valid spawn found.
+        return null;
     }
 
     /**
@@ -88,65 +103,66 @@ public final class SpawnSelector {
      *
      * @param gridX grid coordinate in sample space (centred around 0)
      * @param gridZ grid coordinate in sample space (centred around 0)
-     * @param best  mutable accumulator for the best sample found so far
+     * @param sampleSpacing spacing between samples in grid coordinates
+     * @param ciMin minimum grid coordinate in sample space (inclusive)
+     * @param cjMin minimum grid coordinate in sample space (inclusive)
+     * @return a coarse sample when this tile is valid, otherwise null
      */
-    private static boolean sampleTile(int gridX, int gridZ, TileSample tile) {
-        final int sampleSpacing = COARSE_GRID_SPACING + 1;
+        private static CoarseSample sampleTile(
+            FloatTensor coarseSlice,
+            int gridX,
+            int gridZ,
+            int sampleSpacing,
+            int ciMin,
+            int cjMin) {
         final int ci = gridX * sampleSpacing;
         final int cj = gridZ * sampleSpacing;
 
-        try {
-            final FloatTensor slice = LocalTerrainProvider.getPipelineCoarse(ci, cj, ci + 1, cj + 1);
+        final int sampleI = ci - ciMin;
+        final int sampleJ = cj - cjMin;
+        final int sliceHeight = coarseSlice.shape[1];
+        final int sliceWidth = coarseSlice.shape[2];
 
-            final float weight = slice.data[6];
-            if (weight <= MIN_VALID_WEIGHT) {
-                return false;
-            }
-
-            // channel 0 = elev
-            final float raw = slice.data[0] / weight;
-
-            // Elevation scoring: sign(raw) * raw^2
-            final float elev = Math.copySign(raw * raw, raw);
-
-            LOG.debug("SpawnSelector: coarse sample at ({}, {}) has raw={} elev={} (w={})", ci, cj, raw, elev, weight);
-
-            // Pick first option above sea level
-            if (elev > 0) {
-                LOG.debug("SpawnSelector: coarse sample found ({}, {}) elev={} (w={})", ci, cj, elev, weight);
-                tile.elev = elev;
-                tile.ci = ci;
-                tile.cj = cj;
-                return true;
-            }
-        } catch (Exception e) {
-            LOG.warn("SpawnSelector: coarse sample failed for ({}, {})", ci, cj, e);
+        if (sampleI < 0 || sampleJ < 0 || sampleI >= sliceHeight || sampleJ >= sliceWidth) {
+            LOG.warn("SpawnSelector: coarse sample index out of bounds for ({}, {})", ci, cj);
+            return null;
         }
 
-        return false;
+        final int pixel = sampleI * sliceWidth + sampleJ;
+        final int planeSize = sliceHeight * sliceWidth;
+        final float weight = coarseSlice.data[6 * planeSize + pixel];
+        if (weight <= MIN_VALID_WEIGHT) {
+            return null;
+        }
+
+        // channel 0 = elev
+        final float raw = coarseSlice.data[pixel] / weight;
+
+        // Elevation scoring: sign(raw) * raw^2
+        final float elev = Math.copySign(raw * raw, raw);
+
+        LOG.debug("SpawnSelector: coarse sample at ({}, {}) has raw={} elev={} (w={})", ci, cj, raw, elev, weight);
+
+        // Pick first option above sea level
+        if (elev > 0) {
+            LOG.debug("SpawnSelector: coarse sample found ({}, {}) elev={} (w={})", ci, cj, elev, weight);
+            return new CoarseSample(ci, cj);
+        }
+
+        return null;
     }
 
-    /**
-     * Mutable object for blocks
-     */
-    private static final class TileSample {
-        float elev = Float.POSITIVE_INFINITY;
-        int ci = 0;
-        int cj = 0;
-
-        boolean hasSample() {
-            return elev != Float.POSITIVE_INFINITY;
-        }
+    private record CoarseSample(int ci, int cj) {
     }
 
     /**
      * Refine a coarse tile sample by checking multiple nearby chunks for a safe spawn point.
      *
      * @param world the server world to check for spawn safety
-     * @param tile  the coarse tile sample to refine
+     * @param coarseSample the coarse tile sample to refine
      * @return a safe spawn position within the tile, or a fallback position if none found
      */
-    private static BlockPos findSafeSpawn(ServerWorld world, TileSample tile) {
+    private static BlockPos findSafeSpawn(ServerWorld world, CoarseSample coarseSample) {
         // Convert coarse tile center to block coordinates.
         final int scale = WorldScaleManager.getCurrentScale();
         final int coarseTileBlockSize = 256 * scale;
@@ -156,8 +172,8 @@ public final class SpawnSelector {
         final int chunksToCheck = Math.min(TILE_GRID_SIZE, chunksPerTile);
 
         // Corner of the coarse tile in block coordinates
-        final int tileX = tile.cj * coarseTileBlockSize;
-        final int tileZ = tile.ci * coarseTileBlockSize;
+        final int tileX = coarseSample.cj() * coarseTileBlockSize;
+        final int tileZ = coarseSample.ci() * coarseTileBlockSize;
         final int tileChunkX = tileX / 16;
         final int tileChunkZ = tileZ / 16;
         final int chunkStride = chunksPerTile / chunksToCheck;

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/world/SpawnSelector.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/world/SpawnSelector.java
@@ -23,12 +23,16 @@ public final class SpawnSelector {
 
     private static final Logger LOG = LoggerFactory.getLogger(SpawnSelector.class);
 
-    private static final int COARSE_GRID_SIZE = 10;     // number of samples along one axis
-    private static final int COARSE_GRID_SPACING = 0;   // coarse tiles between samples
-    private static final int TILE_GRID_SIZE = 4;        // number of chunk samples along on axis
+    private static final int COARSE_GRID_SIZE = 10;   // number of samples along one axis
+    private static final int COARSE_GRID_SPACING = 0; // coarse tiles between samples
+    private static final int TILE_GRID_SIZE = 4;      // number of chunk samples along on axis
+    private static final float MIN_VALID_WEIGHT = 1.0e-8f;
+
+    private SpawnSelector() {
+    }
 
     public static SpawnPoint findSpawnPoint(ServerWorld world) {
-        TileSample coarseTile = calculateCoarseSpawnChunk();
+        final TileSample coarseTile = calculateCoarseSpawnChunk();
 
         // If no valid spawn found, default to origin.
         if (!coarseTile.hasSample()) {
@@ -44,22 +48,30 @@ public final class SpawnSelector {
 
     private static TileSample calculateCoarseSpawnChunk() {
         final int half = COARSE_GRID_SIZE / 2;
-        TileSample tile = new TileSample();
+        final TileSample tile = new TileSample();
 
         try {
-            LOG.info("SpawnSelector: starting coarse sampling for Overworld");
-            
+            LOG.debug("SpawnSelector: starting coarse sampling for Overworld");
+
             // Expand in square "rings" around (0, 0) in grid coordinates.
             // r is the ring radius in grid coordinates.
             for (int r = 0; r <= half; r++) {
                 for (int x = -r; x <= r; x++) {
-                    if (sampleTile(x, -r, tile)) { return tile; }
-                    if (r != 0 && sampleTile(x, r, tile)) { return tile; }
+                    if (sampleTile(x, -r, tile)) {
+                        return tile;
+                    }
+                    if (r != 0 && sampleTile(x, r, tile)) {
+                        return tile;
+                    }
                 }
                 if (r > 0) {
                     for (int z = -r + 1; z <= r - 1; z++) {
-                        if (sampleTile(-r, z, tile)) { return tile; }
-                        if (sampleTile(r, z, tile)) { return tile; }
+                        if (sampleTile(-r, z, tile)) {
+                            return tile;
+                        }
+                        if (sampleTile(r, z, tile)) {
+                            return tile;
+                        }
                     }
                 }
             }
@@ -79,28 +91,29 @@ public final class SpawnSelector {
      * @param best  mutable accumulator for the best sample found so far
      */
     private static boolean sampleTile(int gridX, int gridZ, TileSample tile) {
-        int ci = gridX * (COARSE_GRID_SPACING + 1);
-        int cj = gridZ * (COARSE_GRID_SPACING + 1);
+        final int sampleSpacing = COARSE_GRID_SPACING + 1;
+        final int ci = gridX * sampleSpacing;
+        final int cj = gridZ * sampleSpacing;
 
         try {
-            FloatTensor slice = LocalTerrainProvider.getPipelineCoarse(ci, cj, ci + 1, cj + 1);
+            final FloatTensor slice = LocalTerrainProvider.getPipelineCoarse(ci, cj, ci + 1, cj + 1);
 
-            float w = slice.data[6];
-            if (w <= 1e-8f) {
+            final float weight = slice.data[6];
+            if (weight <= MIN_VALID_WEIGHT) {
                 return false;
             }
 
             // channel 0 = elev
-            float raw = slice.data[0] / w;
+            final float raw = slice.data[0] / weight;
 
             // Elevation scoring: sign(raw) * raw^2
-            float elev = Math.copySign(raw * raw, raw);
+            final float elev = Math.copySign(raw * raw, raw);
 
-            LOG.info("SpawnSelector: coarse sample at ({}, {}) has raw={} elev={} (w={})", ci, cj, raw, elev, w);
+            LOG.debug("SpawnSelector: coarse sample at ({}, {}) has raw={} elev={} (w={})", ci, cj, raw, elev, weight);
 
             // Pick first option above sea level
             if (elev > 0) {
-                LOG.info("SpawnSelector: coarse sample found ({}, {}) elev={} (w={})", ci, cj, elev, w);
+                LOG.debug("SpawnSelector: coarse sample found ({}, {}) elev={} (w={})", ci, cj, elev, weight);
                 tile.elev = elev;
                 tile.ci = ci;
                 tile.cj = cj;
@@ -135,28 +148,32 @@ public final class SpawnSelector {
      */
     private static BlockPos findSafeSpawn(ServerWorld world, TileSample tile) {
         // Convert coarse tile center to block coordinates.
-        int scale = WorldScaleManager.getCurrentScale();
-        int coarseTileBlockSize = 256 * scale;
-        int chunkToTileScale = coarseTileBlockSize / 16; // number of chunks per coarse tile along on axis
+        final int scale = WorldScaleManager.getCurrentScale();
+        final int coarseTileBlockSize = 256 * scale;
+        final int chunksPerTile = coarseTileBlockSize / 16; // number of chunks per coarse tile along on axis
 
         // Clamp the number of chunks to maximum possible to avoid resampling
-        int numbChunks = Math.min(TILE_GRID_SIZE, chunkToTileScale);
+        final int chunksToCheck = Math.min(TILE_GRID_SIZE, chunksPerTile);
 
         // Corner of the coarse tile in block coordinates
-        int tileX = tile.cj * coarseTileBlockSize;
-        int tileZ = tile.ci * coarseTileBlockSize;
+        final int tileX = tile.cj * coarseTileBlockSize;
+        final int tileZ = tile.ci * coarseTileBlockSize;
+        final int tileChunkX = tileX / 16;
+        final int tileChunkZ = tileZ / 16;
+        final int chunkStride = chunksPerTile / chunksToCheck;
 
-        LOG.info("SpawnSelector: refining spawn around coarse tile at block ({}, {}) with scale {} ({} chunks per tile)", tileX, tileZ, scale, chunkToTileScale);
+        LOG.debug("SpawnSelector: refining spawn around coarse tile at block ({}, {}) with scale {} ({} chunks per tile)", tileX, tileZ, scale, chunksPerTile);
 
-        for (int ti = 0; ti < numbChunks; ti++) {
-            for (int tj = 0; tj < numbChunks; tj++) {
-                // Calculate the block coordinates of the chunk to check
-                int blockX = tileX + tj * chunkToTileScale * (16 / numbChunks);
-                int blockZ = tileZ + ti * chunkToTileScale * (16 / numbChunks);
-                LOG.info("SpawnSelector: checking chunk at ({}, {}) for safe spawn", blockX, blockZ);
-                BlockPos pos = SpawnLocating.findServerSpawnPoint(world, new ChunkPos(blockX / 16, blockZ / 16));
+        for (int offsetZ = 0; offsetZ < chunksToCheck; offsetZ++) {
+            for (int offsetX = 0; offsetX < chunksToCheck; offsetX++) {
+                // Calculate the chunk coordinates to check.
+                final ChunkPos chunkPos = new ChunkPos(
+                        tileChunkX + offsetX * chunkStride,
+                        tileChunkZ + offsetZ * chunkStride);
+                LOG.debug("SpawnSelector: checking chunk at ({}, {}) for safe spawn", chunkPos.x, chunkPos.z);
+                final BlockPos pos = SpawnLocating.findServerSpawnPoint(world, chunkPos);
                 if (pos != null) {
-                    LOG.info("SpawnSelector: refined spawn found at chunk ({}, {}) -> block ({}, {}, {})", blockX, blockZ, pos.getX(), pos.getY(), pos.getZ());
+                    LOG.debug("SpawnSelector: refined spawn found at chunk ({}, {}) -> block ({}, {}, {})", chunkPos.x, chunkPos.z, pos.getX(), pos.getY(), pos.getZ());
                     return pos;
                 }
             }

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/world/SpawnSelector.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/world/SpawnSelector.java
@@ -1,0 +1,65 @@
+package com.github.xandergos.terraindiffusionmc.world;
+
+import com.github.xandergos.terraindiffusionmc.pipeline.LocalTerrainProvider;
+import com.github.xandergos.terraindiffusionmc.infinitetensor.FloatTensor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+
+/**
+ * Utility to pick an initial world spawn using the terrain models.
+ *
+ * This runs coarse sampling over a small grid then refines a single
+ * candidate with a cheap local heightmap fetch.
+ */
+public final class SpawnSelector {
+    private static final Logger LOG = LoggerFactory.getLogger(SpawnSelector.class);
+
+    public static ChunkPos calculateCoarseSpawnChunk() {
+        try {
+            LOG.info("SpawnSelector: starting coarse sampling for Overworld");
+
+            // Grid parameters: 10x10 sampling in coarse tiles centred at 0
+            final int GRID = 10;
+            final int SPACING = 2;
+            final int HALF = GRID / 2;
+
+            float bestElev = Float.NEGATIVE_INFINITY;
+            int bestCi = 0, bestCj = 0;
+
+            // TODO: This currently just selects the highest elevation...
+            for (int gi = -HALF; gi < HALF; gi++) {
+                for (int gj = -HALF; gj < HALF; gj++) {
+                    int ci = gi * SPACING;
+                    int cj = gj * SPACING;
+                    try {
+                        FloatTensor slice = LocalTerrainProvider.getPipelineCoarse(ci, cj, ci + 1, cj + 1);
+                        // slice shape: [7, H, W] with H=W=1
+                        float w = slice.data[6];
+                        float raw = (w > 1e-8f) ? slice.data[0] / w : 0f; // channel 0 = elev
+                        float elev = (float) (Math.signum(raw) * raw * raw);
+                        if (elev > bestElev) {
+                            bestElev = elev;
+                            bestCi = ci; bestCj = cj;
+                        }
+                    } catch (Exception e) {
+                        LOG.warn("SpawnSelector: coarse sample failed for ({},{})", ci, cj, e);
+                    }
+                }
+            }
+
+            LOG.info("SpawnSelector: best coarse tile ({}, {}) elev={} — refining...", bestCi, bestCj, bestElev);
+
+            // Convert coarse tile center to block coordinates.
+            final int COARSE_TILE_BLOCK = 256;
+            int centerBlockX = bestCj * COARSE_TILE_BLOCK + COARSE_TILE_BLOCK / 2;
+            int centerBlockZ = bestCi * COARSE_TILE_BLOCK + COARSE_TILE_BLOCK / 2;
+
+            return new ChunkPos(new BlockPos(centerBlockX, 0, centerBlockZ));
+        } catch (Exception e) {
+            LOG.error("SpawnSelector: unexpected error", e);
+            return new ChunkPos(new BlockPos(0, 100, 0)); // TODO: This should also use sea level as a default
+        }
+    }
+}

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/world/SpawnSelector.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/world/SpawnSelector.java
@@ -27,6 +27,7 @@ public final class SpawnSelector {
     private static final int COARSE_GRID_SPACING = 0; // coarse tiles between samples
     private static final int TILE_GRID_SIZE = 4;      // number of chunk samples along on axis
     private static final float MIN_VALID_WEIGHT = 1.0e-8f;
+    private static final int MIN_SPAWN_ELEVATION = 10; // minimum elevation for valid spawn Coarse chunk (in meters)
 
     private SpawnSelector() {
     }
@@ -144,7 +145,7 @@ public final class SpawnSelector {
         LOG.debug("SpawnSelector: coarse sample at ({}, {}) has raw={} elev={} (w={})", ci, cj, raw, elev, weight);
 
         // Pick first option above sea level
-        if (elev > 0) {
+        if (elev > MIN_SPAWN_ELEVATION) {
             LOG.debug("SpawnSelector: coarse sample found ({}, {}) elev={} (w={})", ci, cj, elev, weight);
             return new CoarseSample(ci, cj);
         }

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/world/SpawnSelector.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/world/SpawnSelector.java
@@ -2,6 +2,7 @@ package com.github.xandergos.terraindiffusionmc.world;
 
 import com.github.xandergos.terraindiffusionmc.pipeline.LocalTerrainProvider;
 import com.github.xandergos.terraindiffusionmc.infinitetensor.FloatTensor;
+import com.github.xandergos.terraindiffusionmc.world.WorldScaleManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import net.minecraft.util.math.BlockPos;
@@ -52,7 +53,8 @@ public final class SpawnSelector {
             LOG.info("SpawnSelector: best coarse tile ({}, {}) elev={} — refining...", bestCi, bestCj, bestElev);
 
             // Convert coarse tile center to block coordinates.
-            final int COARSE_TILE_BLOCK = 256;
+            int scale = WorldScaleManager.getCurrentScale();
+            final int COARSE_TILE_BLOCK = 256 * scale; // TODO: Need to check what scale is.
             int centerBlockX = bestCj * COARSE_TILE_BLOCK + COARSE_TILE_BLOCK / 2;
             int centerBlockZ = bestCi * COARSE_TILE_BLOCK + COARSE_TILE_BLOCK / 2;
 

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/world/SpawnSelector.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/world/SpawnSelector.java
@@ -2,10 +2,14 @@ package com.github.xandergos.terraindiffusionmc.world;
 
 import com.github.xandergos.terraindiffusionmc.infinitetensor.FloatTensor;
 import com.github.xandergos.terraindiffusionmc.pipeline.LocalTerrainProvider;
+
+import net.minecraft.server.network.SpawnLocating;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.Heightmap;
-import net.minecraft.server.world.ServerWorld;
+import net.minecraft.world.WorldProperties.SpawnPoint;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,71 +23,52 @@ public final class SpawnSelector {
 
     private static final Logger LOG = LoggerFactory.getLogger(SpawnSelector.class);
 
-    // Coarse sampling grid configuration (in coarse-tile coordinates)
-    private static final int GRID_SIZE = 10;    // number of samples along one axis
-    private static final int SPACING = 0;       // coarse tiles between samples
+    private static final int COARSE_GRID_SIZE = 10;     // number of samples along one axis
+    private static final int COARSE_GRID_SPACING = 0;   // coarse tiles between samples
+    private static final int TILE_GRID_SIZE = 4;        // number of chunk samples along on axis
 
-    private SpawnSelector() {
-        // Utility class; no instances
+    public static SpawnPoint findSpawnPoint(ServerWorld world) {
+        TileSample coarseTile = calculateCoarseSpawnChunk();
+
+        // If no valid spawn found, default to origin.
+        if (!coarseTile.hasSample()) {
+            LOG.warn("SpawnSelector: no valid coarse spawn found; defaulting to origin");
+            return SpawnPoint.create(world.getRegistryKey(), BlockPos.ORIGIN, 0.0F, 0.0F);
+        }
+
+        // Refine the coarse tile to find a safe spawn position.
+        BlockPos safeSpawnPos = findSafeSpawn(world, coarseTile);
+
+        return SpawnPoint.create(world.getRegistryKey(), safeSpawnPos, 0.0F, 0.0F);
     }
 
-    public static ChunkPos calculateCoarseSpawnChunk() {
+    private static TileSample calculateCoarseSpawnChunk() {
+        final int half = COARSE_GRID_SIZE / 2;
+        TileSample tile = new TileSample();
 
         try {
             LOG.info("SpawnSelector: starting coarse sampling for Overworld");
-
-            final int half = GRID_SIZE / 2;
-            BlockSample block = new BlockSample();
-
+            
             // Expand in square "rings" around (0, 0) in grid coordinates.
             // r is the ring radius in grid coordinates.
             for (int r = 0; r <= half; r++) {
                 for (int x = -r; x <= r; x++) {
-                    if (samplePoint(x, -r, block) || (r != 0 && samplePoint(x, r, block))) {
-                        return coarseToChunk(block);
-                    }
+                    if (sampleTile(x, -r, tile)) { return tile; }
+                    if (r != 0 && sampleTile(x, r, tile)) { return tile; }
                 }
                 if (r > 0) {
                     for (int z = -r + 1; z <= r - 1; z++) {
-                        if (samplePoint(-r, z, block) || samplePoint(r, z, block)) {
-                            return coarseToChunk(block);
-                        }
+                        if (sampleTile(-r, z, tile)) { return tile; }
+                        if (sampleTile(r, z, tile)) { return tile; }
                     }
                 }
             }
-
-            if (!block.hasSample()) {
-                LOG.warn("SpawnSelector: no valid coarse samples found; falling back to origin");
-                return new ChunkPos(new BlockPos(0, 0, 0));
-            }
-
-            LOG.info("SpawnSelector: best coarse tile ({}, {}) elev={} — refining...",
-                     block.ci, block.cj, block.elev);
-
-            // Convert coarse tile center to block coordinates.
-            // NOTE: ci/cj are in coarse-tile coordinates; mapping to X/Z depends on scale.
-            int scale = WorldScaleManager.getCurrentScale();
-            final int coarseTileBlockSize = 256 * scale;
-
-            int centerBlockX = block.ci * coarseTileBlockSize + coarseTileBlockSize / 2;
-            int centerBlockZ = block.cj * coarseTileBlockSize + coarseTileBlockSize / 2;
-
-            return new ChunkPos(new BlockPos(centerBlockX, 0, centerBlockZ));
         } catch (Exception e) {
             LOG.error("SpawnSelector: unexpected error", e);
-            return new ChunkPos(new BlockPos(0, 0, 0));
         }
-    }
 
-    /**
-     * Convert block coordinates to chunk coordinates
-     *
-     * @param block Coarse block sample object
-     * @return Corner chunk position of course block
-     */
-    private static ChunkPos coarseToChunk(BlockSample block) {
-        int scale = WorldScaleManager.getCurrentScale();
-        return new ChunkPos(block.cj * 256 * scale >> 4, block.ci * 256 * scale >> 4);
+        // No valid spawn found; return an invalid sample.
+        return tile;
     }
 
     /**
@@ -93,9 +78,9 @@ public final class SpawnSelector {
      * @param gridZ grid coordinate in sample space (centred around 0)
      * @param best  mutable accumulator for the best sample found so far
      */
-    private static boolean samplePoint(int gridX, int gridZ, BlockSample block) {
-        int ci = gridX * SPACING;
-        int cj = gridZ * SPACING;
+    private static boolean sampleTile(int gridX, int gridZ, TileSample tile) {
+        int ci = gridX * (COARSE_GRID_SPACING + 1);
+        int cj = gridZ * (COARSE_GRID_SPACING + 1);
 
         try {
             FloatTensor slice = LocalTerrainProvider.getPipelineCoarse(ci, cj, ci + 1, cj + 1);
@@ -111,29 +96,72 @@ public final class SpawnSelector {
             // Elevation scoring: sign(raw) * raw^2
             float elev = Math.copySign(raw * raw, raw);
 
+            LOG.info("SpawnSelector: coarse sample at ({}, {}) has raw={} elev={} (w={})", ci, cj, raw, elev, w);
+
             // Pick first option above sea level
             if (elev > 0) {
-                block.elev = elev;
-                block.ci = ci;
-                block.cj = cj;
+                LOG.info("SpawnSelector: coarse sample found ({}, {}) elev={} (w={})", ci, cj, elev, w);
+                tile.elev = elev;
+                tile.ci = ci;
+                tile.cj = cj;
+                return true;
             }
-            return true;
         } catch (Exception e) {
             LOG.warn("SpawnSelector: coarse sample failed for ({}, {})", ci, cj, e);
-            return false;
         }
+
+        return false;
     }
 
     /**
      * Mutable object for blocks
      */
-    private static final class BlockSample {
+    private static final class TileSample {
         float elev = Float.POSITIVE_INFINITY;
-        int ci;
-        int cj;
+        int ci = 0;
+        int cj = 0;
 
         boolean hasSample() {
             return elev != Float.POSITIVE_INFINITY;
         }
+    }
+
+    /**
+     * Refine a coarse tile sample by checking multiple nearby chunks for a safe spawn point.
+     *
+     * @param world the server world to check for spawn safety
+     * @param tile  the coarse tile sample to refine
+     * @return a safe spawn position within the tile, or a fallback position if none found
+     */
+    private static BlockPos findSafeSpawn(ServerWorld world, TileSample tile) {
+        // Convert coarse tile center to block coordinates.
+        int scale = WorldScaleManager.getCurrentScale();
+        int coarseTileBlockSize = 256 * scale;
+        int chunkToTileScale = coarseTileBlockSize / 16; // number of chunks per coarse tile along on axis
+
+        // Clamp the number of chunks to maximum possible to avoid resampling
+        int numbChunks = Math.min(TILE_GRID_SIZE, chunkToTileScale);
+
+        // Corner of the coarse tile in block coordinates
+        int tileX = tile.cj * coarseTileBlockSize;
+        int tileZ = tile.ci * coarseTileBlockSize;
+
+        LOG.info("SpawnSelector: refining spawn around coarse tile at block ({}, {}) with scale {} ({} chunks per tile)", tileX, tileZ, scale, chunkToTileScale);
+
+        for (int ti = 0; ti < numbChunks; ti++) {
+            for (int tj = 0; tj < numbChunks; tj++) {
+                // Calculate the block coordinates of the chunk to check
+                int blockX = tileX + tj * chunkToTileScale * (16 / numbChunks);
+                int blockZ = tileZ + ti * chunkToTileScale * (16 / numbChunks);
+                LOG.info("SpawnSelector: checking chunk at ({}, {}) for safe spawn", blockX, blockZ);
+                BlockPos pos = SpawnLocating.findServerSpawnPoint(world, new ChunkPos(blockX / 16, blockZ / 16));
+                if (pos != null) {
+                    LOG.info("SpawnSelector: refined spawn found at chunk ({}, {}) -> block ({}, {}, {})", blockX, blockZ, pos.getX(), pos.getY(), pos.getZ());
+                    return pos;
+                }
+            }
+        }
+
+        return new BlockPos(tileX, world.getTopY(Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, tileX, tileZ), tileZ);
     }
 }

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/world/SpawnSelector.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/world/SpawnSelector.java
@@ -1,12 +1,13 @@
 package com.github.xandergos.terraindiffusionmc.world;
 
-import com.github.xandergos.terraindiffusionmc.pipeline.LocalTerrainProvider;
 import com.github.xandergos.terraindiffusionmc.infinitetensor.FloatTensor;
-import com.github.xandergos.terraindiffusionmc.world.WorldScaleManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.github.xandergos.terraindiffusionmc.pipeline.LocalTerrainProvider;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.Heightmap;
+import net.minecraft.server.world.ServerWorld;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utility to pick an initial world spawn using the terrain models.
@@ -15,53 +16,124 @@ import net.minecraft.util.math.ChunkPos;
  * candidate with a cheap local heightmap fetch.
  */
 public final class SpawnSelector {
+
     private static final Logger LOG = LoggerFactory.getLogger(SpawnSelector.class);
 
+    // Coarse sampling grid configuration (in coarse-tile coordinates)
+    private static final int GRID_SIZE = 10;    // number of samples along one axis
+    private static final int SPACING = 0;       // coarse tiles between samples
+
+    private SpawnSelector() {
+        // Utility class; no instances
+    }
+
     public static ChunkPos calculateCoarseSpawnChunk() {
+
         try {
             LOG.info("SpawnSelector: starting coarse sampling for Overworld");
 
-            // Grid parameters: 10x10 sampling in coarse tiles centred at 0
-            final int GRID = 10;
-            final int SPACING = 2;
-            final int HALF = GRID / 2;
+            final int half = GRID_SIZE / 2;
+            BlockSample block = new BlockSample();
 
-            float bestElev = Float.NEGATIVE_INFINITY;
-            int bestCi = 0, bestCj = 0;
-
-            // TODO: This currently just selects the highest elevation...
-            for (int gi = -HALF; gi < HALF; gi++) {
-                for (int gj = -HALF; gj < HALF; gj++) {
-                    int ci = gi * SPACING;
-                    int cj = gj * SPACING;
-                    try {
-                        FloatTensor slice = LocalTerrainProvider.getPipelineCoarse(ci, cj, ci + 1, cj + 1);
-                        // slice shape: [7, H, W] with H=W=1
-                        float w = slice.data[6];
-                        float raw = (w > 1e-8f) ? slice.data[0] / w : 0f; // channel 0 = elev
-                        float elev = (float) (Math.signum(raw) * raw * raw);
-                        if (elev > bestElev) {
-                            bestElev = elev;
-                            bestCi = ci; bestCj = cj;
+            // Expand in square "rings" around (0, 0) in grid coordinates.
+            // r is the ring radius in grid coordinates.
+            for (int r = 0; r <= half; r++) {
+                for (int x = -r; x <= r; x++) {
+                    if (samplePoint(x, -r, block) || (r != 0 && samplePoint(x, r, block))) {
+                        return coarseToChunk(block);
+                    }
+                }
+                if (r > 0) {
+                    for (int z = -r + 1; z <= r - 1; z++) {
+                        if (samplePoint(-r, z, block) || samplePoint(r, z, block)) {
+                            return coarseToChunk(block);
                         }
-                    } catch (Exception e) {
-                        LOG.warn("SpawnSelector: coarse sample failed for ({},{})", ci, cj, e);
                     }
                 }
             }
 
-            LOG.info("SpawnSelector: best coarse tile ({}, {}) elev={} — refining...", bestCi, bestCj, bestElev);
+            if (!block.hasSample()) {
+                LOG.warn("SpawnSelector: no valid coarse samples found; falling back to origin");
+                return new ChunkPos(new BlockPos(0, 0, 0));
+            }
+
+            LOG.info("SpawnSelector: best coarse tile ({}, {}) elev={} — refining...",
+                     block.ci, block.cj, block.elev);
 
             // Convert coarse tile center to block coordinates.
+            // NOTE: ci/cj are in coarse-tile coordinates; mapping to X/Z depends on scale.
             int scale = WorldScaleManager.getCurrentScale();
-            final int COARSE_TILE_BLOCK = 256 * scale; // TODO: Need to check what scale is.
-            int centerBlockX = bestCj * COARSE_TILE_BLOCK + COARSE_TILE_BLOCK / 2;
-            int centerBlockZ = bestCi * COARSE_TILE_BLOCK + COARSE_TILE_BLOCK / 2;
+            final int coarseTileBlockSize = 256 * scale;
+
+            int centerBlockX = block.ci * coarseTileBlockSize + coarseTileBlockSize / 2;
+            int centerBlockZ = block.cj * coarseTileBlockSize + coarseTileBlockSize / 2;
 
             return new ChunkPos(new BlockPos(centerBlockX, 0, centerBlockZ));
         } catch (Exception e) {
             LOG.error("SpawnSelector: unexpected error", e);
-            return new ChunkPos(new BlockPos(0, 100, 0)); // TODO: This should also use sea level as a default
+            return new ChunkPos(new BlockPos(0, 0, 0));
+        }
+    }
+
+    /**
+     * Convert block coordinates to chunk coordinates
+     *
+     * @param block Coarse block sample object
+     * @return Corner chunk position of course block
+     */
+    private static ChunkPos coarseToChunk(BlockSample block) {
+        int scale = WorldScaleManager.getCurrentScale();
+        return new ChunkPos(block.cj * 256 * scale >> 4, block.ci * 256 * scale >> 4);
+    }
+
+    /**
+     * Sample a single point in the coarse grid.
+     *
+     * @param gridX grid coordinate in sample space (centred around 0)
+     * @param gridZ grid coordinate in sample space (centred around 0)
+     * @param best  mutable accumulator for the best sample found so far
+     */
+    private static boolean samplePoint(int gridX, int gridZ, BlockSample block) {
+        int ci = gridX * SPACING;
+        int cj = gridZ * SPACING;
+
+        try {
+            FloatTensor slice = LocalTerrainProvider.getPipelineCoarse(ci, cj, ci + 1, cj + 1);
+
+            float w = slice.data[6];
+            if (w <= 1e-8f) {
+                return false;
+            }
+
+            // channel 0 = elev
+            float raw = slice.data[0] / w;
+
+            // Elevation scoring: sign(raw) * raw^2
+            float elev = Math.copySign(raw * raw, raw);
+
+            // Pick first option above sea level
+            if (elev > 0) {
+                block.elev = elev;
+                block.ci = ci;
+                block.cj = cj;
+            }
+            return true;
+        } catch (Exception e) {
+            LOG.warn("SpawnSelector: coarse sample failed for ({}, {})", ci, cj, e);
+            return false;
+        }
+    }
+
+    /**
+     * Mutable object for blocks
+     */
+    private static final class BlockSample {
+        float elev = Float.POSITIVE_INFINITY;
+        int ci;
+        int cj;
+
+        boolean hasSample() {
+            return elev != Float.POSITIVE_INFINITY;
         }
     }
 }

--- a/src/main/resources/terrain-diffusion-mc.mixins.json
+++ b/src/main/resources/terrain-diffusion-mc.mixins.json
@@ -4,7 +4,8 @@
   "package": "com.github.xandergos.terraindiffusionmc.mixin",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
-    "BiomeMixin"
+    "BiomeMixin",
+    "MinecraftServerMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Currently players often spawn in the middle of the ocean. This PR aims to use the models provided by terrain diffusion to find a suitable world spawn. Even if the oceans are tens of thousand of blocks wide. 

The idea for this PR is to sparsely sample using the coarse model, and then to only use the finer model to find the best spot to spawn in that section. While this might slow down world creation a little, I think this is a comparatively performant way to find a suitable world spawn.

This should solve the following issues:
#42 
#89 
