### PR TITLE
Override world spawn to land using coarse elevation map

### DIFF
--- a/CUDA_INSTALL.md
+++ b/CUDA_INSTALL.md
@@ -2,8 +2,6 @@
 
 This guide is only needed for the `-cuda` build of Terrain Diffusion MC. If you downloaded the `-windows` build, no setup is required.
 
-> **On Linux?** Follow the [Official ONNX Runtime instructions](https://onnxruntime.ai/docs/install/#cuda-and-cudnn). The required CUDA and cuDNN versions are the same as below.
-
 ## Installation Steps (Windows)
 
 #### Step 1: Install CUDA 12
@@ -39,6 +37,123 @@ Find the cuDNN folder containing `cudnn64_9.dll`. It should look something like 
 #### Step 5: Restart your PC
 
 You may need to restart your PC for PATH changes to take effect. Once you're back, you're all set.
+
+
+---
+
+## Linux
+
+The mod requires **CUDA 12.x** and **cuDNN 9.x**. The approach differs depending on your distro.
+
+> ⚠️ **Do not install CUDA 13** — it is not supported yet. If `nvidia-smi` shows "CUDA Version: 13.x", that is just your driver's maximum supported version, not an installed toolkit. You still need to install CUDA 12.x separately.
+
+### Option A: Ubuntu / Debian (Recommended)
+
+This is the simplest path. NVIDIA provides native `.deb` packages.
+
+#### Step 1: Install CUDA 12
+
+Go to the [CUDA Toolkit Archive](https://developer.nvidia.com/cuda-toolkit-archive), select your Ubuntu version, and follow the `deb (network)` instructions. Make sure you pick a **12.x** version.
+
+#### Step 2: Install cuDNN 9
+
+Go to the [cuDNN download page](https://developer.nvidia.com/cudnn-downloads), select:
+- Linux → x86_64 → Ubuntu → your version → **Deb**
+- Select **CUDA 12** and download
+
+Install with:
+```bash
+sudo dpkg -i cudnn-local-repo-*.deb
+sudo apt-get update
+sudo apt-get install libcudnn9-cuda-12
+```
+#### Step 3: Set LD_LIBRARY_PATH
+
+Before launching Minecraft, set the library path in your terminal:
+
+```bash
+export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu
+```
+
+Then launch your Minecraft launcher from the same terminal session.
+
+> **Prism Launcher / MultiMC users:** You can set this per-instance instead. Go to instance → **Edit** → **Settings** → **Environment Variables** and add `LD_LIBRARY_PATH` = `/usr/lib/x86_64-linux-gnu`. This way you don't need the terminal export every time.
+
+Launch the game. Done.
+
+---
+
+### Option B: Arch Linux (and Arch-based distros like EndeavourOS, Manjaro)
+
+Arch does not package CUDA 12.x and 13.x separately in the official repos, so the cleanest approach for users who need to keep another CUDA version is to install CUDA 12.x via the `.run` file into an isolated directory.
+
+#### Step 1: Download CUDA 12.x runfile
+
+Go to the [CUDA Toolkit Archive](https://developer.nvidia.com/cuda-toolkit-archive) and download any distro's **12.x** version as a **Linux runfile (local)**. CUDA 12.0 is known to work.
+
+#### Step 2: Install CUDA 12 into an isolated directory
+
+> ℹ️ This does **not** touch your existing CUDA installation or GPU drivers.
+
+Arch's libxml2 ships under a different versioned name than the runfile expects. Create a symlink first:
+```bash
+sudo ln -s /usr/lib/libxml2.so /usr/lib/libxml2.so.2
+```
+
+Then install:
+```bash
+sudo LD_LIBRARY_PATH=/usr/lib:$LD_LIBRARY_PATH sh cuda_12.x.x_*.run \
+  --silent \
+  --toolkit \
+  --toolkitpath=/usr/local/cuda-12.0 \
+  --no-opengl-libs \
+  --override
+```
+
+The `--override` flag bypasses a gcc version check that fails on Arch. The three "no version information available" warnings that appear are harmless.
+
+Verify it worked:
+```bash
+ls /usr/local/cuda-12.0/lib64/libcudart.so*
+# Should show: libcudart.so.12
+```
+
+#### Step 3: Download and install cuDNN 9.x
+
+Go to the [cuDNN download page](https://developer.nvidia.com/cudnn-downloads) and select:
+- Linux → x86_64 → **Tarball** → **CUDA 12** → **Full**
+
+> ⚠️ Make sure you select **CUDA 12**, not CUDA 13. The filename should contain `cuda12`.
+
+Extract and copy into your CUDA 12 directory:
+```bash
+tar -xf cudnn-linux-x86_64-9.*.tar.xz
+sudo cp cudnn-linux-x86_64-9.*_cuda12-archive/include/cudnn*.h /usr/local/cuda-12.0/include/
+sudo cp -P cudnn-linux-x86_64-9.*_cuda12-archive/lib/libcudnn* /usr/local/cuda-12.0/lib64/
+sudo chmod a+r /usr/local/cuda-12.0/lib64/libcudnn*
+```
+
+Verify:
+```bash
+ls /usr/local/cuda-12.0/lib64/libcudnn.so*
+# Should show: libcudnn.so.9
+```
+
+#### Step 4: Set LD_LIBRARY_PATH
+
+Before launching Minecraft, set the library path in your terminal:
+
+```bash
+export LD_LIBRARY_PATH=/usr/local/cuda-12.0/lib64
+```
+
+Then launch your Minecraft launcher from the same terminal session.
+
+> **Prism Launcher / MultiMC users:** You can set this per-instance instead. Go to instance → **Edit** → **Settings** → **Environment Variables** and add `LD_LIBRARY_PATH` = `/usr/local/cuda-12.0/lib64`. This tells the JVM exactly where to find the CUDA and cuDNN libraries without affecting anything else on your system.
+
+Launch the game. Done.
+
+---
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Use the `-cuda` build only if you are on Linux, or have an NVIDIA GPU and prefer
 1. Download the mod jar from [Releases](https://github.com/xandergos/terrain-diffusion-mc/releases) for your Minecraft version and place it in your Minecraft `mods/` folder. Make sure the Minecraft version matches.
 2. Launch Minecraft, at least once online to download the models (~2.5GB).
 3. Create a world, and select the **Terrain Diffusion** world type. Click **Customize** to set the `World Scale` (see [Per-world settings](#per-world-settings) below).
+4. You may spawn in ocean. This is not a bug, the world just has a lot of water. Use `/td-explore` (see below) to find land.
 
 ## Exploring the World
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Terrain Diffusion Fabric Mod [[Modrinth]](https://modrinth.com/mod/terrain-diffusion)
 
-#### UPDATE: The research behind this mod has been accepted to SIGGRAPH 2026, the world's premier graphics conference! That means the research was independently peer reviewed and recognized as a significant contribution to the field. Enjoy the mod!
+#### UPDATE: The research behind this mod has been accepted to SIGGRAPH 2026, the world's premier graphics conference! That means the research was officially peer reviewed and recognized as a significant contribution to the field. Enjoy the mod!
 
 This is a Minecraft Fabric mod integrating [Terrain Diffusion](https://github.com/xandergos/terrain-diffusion).
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Terrain Diffusion Fabric Mod
 
+**Now [availabe on Modrinth](https://modrinth.com/mod/terrain-diffusion)**
+
 This is a Minecraft Fabric mod integrating [Terrain Diffusion](https://github.com/xandergos/terrain-diffusion).
 
 ## Which version should I use?

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Terrain Diffusion Fabric Mod
 
-**Now [availabe on Modrinth](https://modrinth.com/mod/terrain-diffusion)**
+**Now [available on Modrinth](https://modrinth.com/mod/terrain-diffusion)**
 
 This is a Minecraft Fabric mod integrating [Terrain Diffusion](https://github.com/xandergos/terrain-diffusion).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Terrain Diffusion Fabric Mod
+# Terrain Diffusion Fabric Mod [[Modrinth]](https://modrinth.com/mod/terrain-diffusion)
 
-### Now [available on Modrinth](https://modrinth.com/mod/terrain-diffusion)
+#### UPDATE: The research behind this mod has been accepted to SIGGRAPH 2026, the world's premier graphics conference! That means the research was independently peer reviewed and recognized as a significant contribution to the field. Enjoy the mod!
 
 This is a Minecraft Fabric mod integrating [Terrain Diffusion](https://github.com/xandergos/terrain-diffusion).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Terrain Diffusion Fabric Mod
 
-**Now [available on Modrinth](https://modrinth.com/mod/terrain-diffusion)**
+### Now [available on Modrinth](https://modrinth.com/mod/terrain-diffusion)
 
 This is a Minecraft Fabric mod integrating [Terrain Diffusion](https://github.com/xandergos/terrain-diffusion).
 

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/config/TerrainDiffusionConfig.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/config/TerrainDiffusionConfig.java
@@ -53,6 +53,16 @@ public final class TerrainDiffusionConfig {
         return readBoolean("validate_model", DEFAULT_VALIDATE_MODEL);
     }
 
+    /** Initial coarse-pixel radius for spawn land search (NxN region centered at origin). */
+    public static int spawnSearchInitialSize() {
+        return readInt("spawn_search.initial_size", 16);
+    }
+
+    /** Maximum coarse-pixel region size for spawn land search before giving up. */
+    public static int spawnSearchMaxSize() {
+        return readInt("spawn_search.max_size", 128);
+    }
+
     /** Region side length in blocks. Must be a positive power of 2 (128, 256, 512, ...). */
     public static int tileSize() {
         int configuredTileSize = readInt("tile_size", DEFAULT_TILE_SIZE);

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/mixin/MinecraftServerMixin.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/mixin/MinecraftServerMixin.java
@@ -1,0 +1,32 @@
+package com.github.xandergos.terraindiffusionmc.mixin;
+
+import com.github.xandergos.terraindiffusionmc.pipeline.SpawnSelector;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.WorldProperties;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.ChunkLoadProgress;
+import net.minecraft.world.level.ServerWorldProperties;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MinecraftServer.class)
+public class MinecraftServerMixin {
+
+    @Inject(method = "setupSpawn", at = @At("HEAD"), cancellable = true)
+    private static void overrideWorldSpawn(ServerWorld world, ServerWorldProperties worldProperties,
+                                           boolean bonusChest, boolean debugWorld,
+                                           ChunkLoadProgress loadProgress, CallbackInfo ci) {
+        if (!world.getRegistryKey().equals(World.OVERWORLD)) {
+            return;
+        }
+
+        BlockPos spawnPos = SpawnSelector.findSpawnBlockPos();
+        worldProperties.setSpawnPoint(
+                WorldProperties.SpawnPoint.create(World.OVERWORLD, spawnPos, 0f, 0f));
+        ci.cancel();
+    }
+}

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/pipeline/SpawnSelector.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/pipeline/SpawnSelector.java
@@ -1,0 +1,172 @@
+package com.github.xandergos.terraindiffusionmc.pipeline;
+
+import com.github.xandergos.terraindiffusionmc.config.TerrainDiffusionConfig;
+import com.github.xandergos.terraindiffusionmc.infinitetensor.FloatTensor;
+import com.github.xandergos.terraindiffusionmc.world.HeightConverter;
+import com.github.xandergos.terraindiffusionmc.world.WorldScaleManager;
+import net.minecraft.util.math.BlockPos;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Finds a suitable land spawn point by querying the coarse elevation map near the world origin.
+ *
+ * <p>The search starts with a configurable NxN coarse-pixel region centered at (0, 0) and
+ * expands by 8 coarse pixels per side each iteration until land is found or the max size is
+ * reached. The first pixel (nearest to center) that is itself above sea level and fully
+ * surrounded by 8 above-sea-level neighbors is chosen.
+ */
+public final class SpawnSelector {
+    private static final Logger LOG = LoggerFactory.getLogger(SpawnSelector.class);
+
+    /**
+     * Coarse pixels to native pixels: 1 coarse unit = 32 * latentCompression native pixels.
+     * Matches the conversion used in WorldPipeline#computeClimate.
+     */
+    private static final int COARSE_TO_NATIVE = 32 * WorldPipelineModelConfig.latentCompression();
+
+    private SpawnSelector() {}
+
+    /**
+     * Finds the nearest fully-land coarse pixel to (0, 0) and converts it to a block-space
+     * {@link BlockPos}. Falls back to (0, 64, 0) if no suitable pixel is found within the
+     * configured maximum search region.
+     */
+    public static BlockPos findSpawnBlockPos() {
+        int initialSize = TerrainDiffusionConfig.spawnSearchInitialSize();
+        int maxSize = TerrainDiffusionConfig.spawnSearchMaxSize();
+        int scale = WorldScaleManager.getCurrentScale();
+
+        for (int regionSize = initialSize; regionSize <= maxSize; regionSize += 8) {
+            int halfSize = regionSize / 2;
+            // Coarse pixel bounds centered at native origin (coarse 0,0)
+            int ci0 = -halfSize;
+            int cj0 = -halfSize;
+            int ci1 = halfSize;
+            int cj1 = halfSize;
+
+            LOG.info("Querying coarse map to find spawn. Region size: {} x {}", regionSize, regionSize);
+            FloatTensor coarse;
+            try {
+                coarse = LocalTerrainProvider.getPipelineCoarse(ci0, cj0, ci1, cj1);
+            } catch (Exception e) {
+                LOG.error("SpawnSelector: failed to query coarse map at size {}", regionSize, e);
+                continue;
+            }
+
+            int H = ci1 - ci0;
+            int W = cj1 - cj0;
+
+            BlockPos candidate = findNearestLandPixel(coarse, H, W, ci0, cj0, scale);
+            if (candidate != null) {
+                LOG.info("SpawnSelector: found land spawn at {} (coarse region {}x{})", candidate, regionSize, regionSize);
+                return candidate;
+            }
+
+            LOG.debug("SpawnSelector: no land found in {}x{} coarse region, expanding", regionSize, regionSize);
+        }
+
+        LOG.warn("SpawnSelector: no land found within max coarse region {}x{}, falling back to origin", maxSize, maxSize);
+        return fallbackToOrigin();
+    }
+
+    /**
+     * Returns the Minecraft block Y for the given block (X, Z), clamped to at least 64.
+     * Falls back to 64 if the heightmap cannot be fetched.
+     */
+    private static int heightmapY(int blockX, int blockZ) {
+        try {
+            LocalTerrainProvider.HeightmapData data =
+                    LocalTerrainProvider.getInstance().fetchHeightmap(blockZ, blockX, blockZ + 1, blockX + 1);
+            return Math.max(HeightConverter.convertToMinecraftHeight(data.heightmap[0][0]), 64);
+        } catch (Exception e) {
+            LOG.error("SpawnSelector: failed to fetch heightmap at ({}, {})", blockX, blockZ, e);
+            return 64;
+        }
+    }
+
+    /**
+     * Returns a spawn position at block (0, 0) using the heightmap Y, clamped to at least 64.
+     */
+    private static BlockPos fallbackToOrigin() {
+        LOG.warn("SpawnSelector: falling back to origin (0, ?, 0)");
+        return new BlockPos(0, heightmapY(0, 0), 0);
+    }
+
+    /**
+     * Scans the coarse tensor in order of increasing Chebyshev distance from the center,
+     * returning the block position of the first pixel that is above sea level and fully
+     * surrounded by 8 above-sea-level neighbors.
+     *
+     * @param coarse the coarse tensor with shape [7, H, W]
+     * @param H      height in coarse pixels
+     * @param W      width in coarse pixels
+     * @param ci0    coarse row offset of the top-left corner
+     * @param cj0    coarse col offset of the top-left corner
+     * @param scale  current world scale (blocks per native pixel)
+     * @return block-space position, or null if no valid pixel found
+     */
+    private static BlockPos findNearestLandPixel(FloatTensor coarse, int H, int W,
+                                                  int ci0, int cj0, int scale) {
+        // Center of the queried region in local (row, col) indices
+        int centerRow = H / 2;
+        int centerCol = W / 2;
+
+        // Scan by increasing Chebyshev distance so the first hit is nearest to origin
+        int maxDist = Math.max(H, W);
+        for (int dist = 0; dist <= maxDist; dist++) {
+            // Iterate over all pixels at this Chebyshev distance
+            for (int dr = -dist; dr <= dist; dr++) {
+                for (int dc = -dist; dc <= dist; dc++) {
+                    // Only visit pixels on the outer shell of this distance
+                    if (Math.abs(dr) != dist && Math.abs(dc) != dist) continue;
+
+                    int row = centerRow + dr;
+                    int col = centerCol + dc;
+
+                    // Need a 1-pixel border for neighbor checks
+                    if (row < 1 || row >= H - 1 || col < 1 || col >= W - 1) continue;
+
+                    if (isFullyOnLand(coarse, row, col, H, W)) {
+                        // Convert local coarse index to absolute coarse coords
+                        int ci = ci0 + row;
+                        int cj = cj0 + col;
+                        // Coarse -> native -> block (j=X axis, i=Z axis)
+                        int blockX = cj * COARSE_TO_NATIVE * scale;
+                        int blockZ = ci * COARSE_TO_NATIVE * scale;
+                        int blockY = heightmapY(blockX, blockZ);
+                        return new BlockPos(blockX, blockY, blockZ);
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns true if the pixel at (row, col) and all 8 of its neighbors have a positive
+     * unnormalized elevation (i.e. are above sea level).
+     */
+    private static boolean isFullyOnLand(FloatTensor coarse, int row, int col, int H, int W) {
+        for (int dr = -1; dr <= 1; dr++) {
+            for (int dc = -1; dc <= 1; dc++) {
+                if (!isLand(coarse, row + dr, col + dc, H, W)) return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * A coarse pixel is considered land when its unnormalized channel-0 value is positive.
+     * Channel 6 is the blend weight; channel 0 / channel 6 gives the unnormalized elevation
+     * (positive = land, zero or negative = ocean).
+     */
+    private static boolean isLand(FloatTensor coarse, int row, int col, int H, int W) {
+        int pixelCount = H * W;
+        int px = row * W + col;
+        float weight = coarse.data[6 * pixelCount + px];
+        if (weight <= 1e-6f) return false;
+        float elevSqrt = coarse.data[px] / weight;  // channel 0
+        return elevSqrt > 0f;
+    }
+}

--- a/src/main/resources/terrain-diffusion-mc.mixins.json
+++ b/src/main/resources/terrain-diffusion-mc.mixins.json
@@ -4,7 +4,8 @@
   "package": "com.github.xandergos.terraindiffusionmc.mixin",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
-    "BiomeMixin"
+    "BiomeMixin",
+    "MinecraftServerMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/main/resources/terrain-diffusion-mc.properties
+++ b/src/main/resources/terrain-diffusion-mc.properties
@@ -21,3 +21,8 @@ explorer.port=19801
 # Use larger values to generate in larger batches (more chunks per second)
 # Use smaller values to generate in smaller batches (most responsive)
 tile_size=256
+
+# Spawn search: coarse-pixel region sizes for land detection near (0,0).
+# Starts at initial_size x initial_size, expands by 8 each iteration up to max_size x max_size.
+spawn_search.initial_size=16
+spawn_search.max_size=128


### PR DESCRIPTION
Add SpawnSelector that queries the coarse diffusion map in expanding regions centered at (0,0) to find the nearest fully-land pixel (all 9 neighbors above sea level). MinecraftServerMixin injects into setupSpawn to replace vanilla spawn logic with the result. Region sizes and max search radius are configurable via terrain-diffusion-mc.properties.