### PR TITLE
Added config options for servers

### DIFF
--- a/src/main/java/com/github/xandergos/terraindiffusionmc/TerrainDiffusionMc.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/TerrainDiffusionMc.java
@@ -1,5 +1,6 @@
 package com.github.xandergos.terraindiffusionmc;
 
+import com.github.xandergos.terraindiffusionmc.config.TerrainDiffusionConfig;
 import com.github.xandergos.terraindiffusionmc.explorer.ExplorerServer;
 import com.github.xandergos.terraindiffusionmc.pipeline.LocalTerrainProvider;
 import com.github.xandergos.terraindiffusionmc.pipeline.ModelAssetManager;
@@ -58,7 +59,12 @@ public class TerrainDiffusionMc implements ModInitializer {
     private static int executeExplore(CommandContext<ServerCommandSource> ctx) {
         try {
             int port = ExplorerServer.startIfNotRunning();
-            String url = "http://localhost:" + port;
+
+            // If the explorer is bound to 0.0.0.0, the clients probably need the external IP to connect to it
+            String address = TerrainDiffusionConfig.explorerAddress().equals("0.0.0.0")
+                    ? ExplorerServer.getPublicIp()
+                    : "localhost";
+            String url = "http://" + address + ":" + port;
             MutableText link = Text.literal(url)
                     .styled(s -> s.withClickEvent(new ClickEvent.OpenUrl(URI.create(url)))
                                   .withUnderline(true));

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/config/TerrainDiffusionConfig.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/config/TerrainDiffusionConfig.java
@@ -17,6 +17,7 @@ public final class TerrainDiffusionConfig {
     private static final boolean DEFAULT_OFFLOAD_MODELS = true;
     private static final boolean DEFAULT_VALIDATE_MODEL = true;
     private static final int DEFAULT_EXPLORER_PORT = 19801;
+    private static final String DEFAULT_EXPLORER_ADDRESS = "127.0.0.1";
     private static final int DEFAULT_TILE_SIZE = 256;
     private static final int DEFAULT_WORLD_SCALE = 2;
 
@@ -50,6 +51,11 @@ public final class TerrainDiffusionConfig {
     /** TCP port for the local terrain explorer HTTP server. */
     public static int explorerPort() {
         return readInt("explorer.port", DEFAULT_EXPLORER_PORT);
+    }
+
+    /** Listening address for the local terrain explorer HTTP server. */
+    public static String explorerAddress() {
+        return readString("explorer.address", DEFAULT_EXPLORER_ADDRESS);
     }
 
     /** Whether to validate SHA-256 for pre-existing local model files before use. */

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/config/TerrainDiffusionConfig.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/config/TerrainDiffusionConfig.java
@@ -1,5 +1,6 @@
 package com.github.xandergos.terraindiffusionmc.config;
 
+import com.github.xandergos.terraindiffusionmc.world.WorldScaleManager;
 import net.fabricmc.loader.api.FabricLoader;
 
 import java.io.IOException;
@@ -17,6 +18,7 @@ public final class TerrainDiffusionConfig {
     private static final boolean DEFAULT_VALIDATE_MODEL = true;
     private static final int DEFAULT_EXPLORER_PORT = 19801;
     private static final int DEFAULT_TILE_SIZE = 256;
+    private static final int DEFAULT_WORLD_SCALE = 2;
 
     static {
         loadDefaults();
@@ -73,6 +75,15 @@ public final class TerrainDiffusionConfig {
             return DEFAULT_TILE_SIZE;
         }
         return configuredTileSize;
+    }
+
+    public static int defaultScale() {
+        int configuredScale = readInt("default_scale", DEFAULT_WORLD_SCALE);
+        if (configuredScale < WorldScaleManager.MIN_SCALE || configuredScale > WorldScaleManager.MAX_SCALE) {
+            System.err.println("Invalid default_scale: " + configuredScale + ", using default " + DEFAULT_WORLD_SCALE);
+            return DEFAULT_WORLD_SCALE;
+        }
+        return configuredScale;
     }
 
     private static void loadDefaults() {

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/explorer/ExplorerServer.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/explorer/ExplorerServer.java
@@ -13,12 +13,10 @@ import org.slf4j.LoggerFactory;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
@@ -50,6 +48,36 @@ public final class ExplorerServer {
 
     private ExplorerServer() {}
 
+    public static String getPublicIp() throws Exception {
+
+        String[] services = {
+                "http://checkip.amazonaws.com",
+                "https://api.ipify.org",
+                "https://icanhazip.com"
+        };
+
+        for (String service : services) {
+            try {
+                URL url = URI.create(service).toURL();
+
+                try (BufferedReader in = new BufferedReader(
+                        new InputStreamReader(url.openStream()))) {
+
+                    String ip = in.readLine();
+
+                    if (ip != null && !ip.isBlank()) {
+                        return ip.trim();
+                    }
+                }
+
+            } catch (Exception e) {
+                System.out.println("Failed to reach: " + service);
+            }
+        }
+
+        throw new Exception("All IP services failed.");
+    }
+
     // =========================================================================
     // Lifecycle
     // =========================================================================
@@ -60,7 +88,8 @@ public final class ExplorerServer {
     public static synchronized int startIfNotRunning() throws IOException {
         if (SERVER != null) return SERVER_PORT;
         int port = TerrainDiffusionConfig.explorerPort();
-        InetSocketAddress addr = new InetSocketAddress("127.0.0.1", port);
+        String address = TerrainDiffusionConfig.explorerAddress();
+        InetSocketAddress addr = new InetSocketAddress(address, port);
         HttpServer server = HttpServer.create(addr, 0);
         server.createContext("/", ExplorerServer::handleRoot);
         server.createContext("/api/status", ExplorerServer::handleStatus);
@@ -80,7 +109,7 @@ public final class ExplorerServer {
         server.start();
         SERVER = server;
         SERVER_PORT = port;
-        LOG.info("Terrain explorer started at http://127.0.0.1:{}", port);
+        LOG.info("Terrain explorer started at http://{}:{}", address, port);
         return port;
     }
 

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/world/WorldScaleManager.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/world/WorldScaleManager.java
@@ -1,13 +1,14 @@
 package com.github.xandergos.terraindiffusionmc.world;
 
+import com.github.xandergos.terraindiffusionmc.config.TerrainDiffusionConfig;
 import net.minecraft.server.world.ServerWorld;
 
 /**
  * Runtime access for world-scoped terrain scale.
  */
 public final class WorldScaleManager {
-    public static final int DEFAULT_SCALE = 2;
-    private static final int MIN_SCALE = 1;
+    public static final int DEFAULT_SCALE = TerrainDiffusionConfig.defaultScale();
+    public static final int MIN_SCALE = 1;
     public static final int MAX_SCALE = 6;
 
     private static volatile int currentScale = DEFAULT_SCALE;
@@ -19,7 +20,7 @@ public final class WorldScaleManager {
      * Loads or creates per-world scale settings and sets the active runtime value.
      *
      * <p>If the world has no explicit stored scale yet, this applies pending
-     * world-creation selection when present, otherwise falls back to {@value #DEFAULT_SCALE}.
+     * world-creation selection when present, otherwise falls back to 2.
      */
     public static void initializeForWorld(ServerWorld serverWorld) {
         WorldScaleSettingsState worldScaleSettingsState = serverWorld.getPersistentStateManager()

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/world/WorldScaleManager.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/world/WorldScaleManager.java
@@ -20,7 +20,7 @@ public final class WorldScaleManager {
      * Loads or creates per-world scale settings and sets the active runtime value.
      *
      * <p>If the world has no explicit stored scale yet, this applies pending
-     * world-creation selection when present, otherwise falls back to 2.
+     * world-creation selection when present, otherwise falls back to the value set in terrain-diffusion-mc.properties.
      */
     public static void initializeForWorld(ServerWorld serverWorld) {
         WorldScaleSettingsState worldScaleSettingsState = serverWorld.getPersistentStateManager()

--- a/src/main/resources/terrain-diffusion-mc.properties
+++ b/src/main/resources/terrain-diffusion-mc.properties
@@ -13,8 +13,13 @@ inference.offload_models=true
 # Set to false to allow custom user-provided models/config without hash checks.
 validate_model=true
 
-# Port for the local terrain explorer web UI (started with /td-explore command).
+# Port for the terrain explorer web UI (started with /td-explore command).
 explorer.port=19801
+
+# Listening address for the terrain explorer web UI.
+# Set to 0.0.0.0 to allow access outside your local network.
+# Useful for servers to allow other players to view the terrain map.
+explorer.address=127.0.0.1
 
 # Terrain generation region side length in blocks. Must be a power of 2.
 # Examples: 128, 256, 512, 1024.
@@ -24,7 +29,7 @@ tile_size=256
 
 # Default world scale for Terrain Diffusion worlds.
 # Must be between 1 and 6 inclusive.
-# Use it in servers to set the world scale.
+# Useful for servers to set the world scale.
 default_scale=2
 
 # Spawn search: coarse-pixel region sizes for land detection near (0,0).

--- a/src/main/resources/terrain-diffusion-mc.properties
+++ b/src/main/resources/terrain-diffusion-mc.properties
@@ -22,6 +22,11 @@ explorer.port=19801
 # Use smaller values to generate in smaller batches (most responsive)
 tile_size=256
 
+# Default world scale for Terrain Diffusion worlds.
+# Must be between 1 and 6 inclusive.
+# Use it in servers to set the world scale.
+default_scale=2
+
 # Spawn search: coarse-pixel region sizes for land detection near (0,0).
 # Starts at initial_size x initial_size, expands by 8 each iteration up to max_size x max_size.
 spawn_search.initial_size=16


### PR DESCRIPTION
Added default_scale in terrain-diffusion-mc.properties to allow dedicated servers to change the world scale, and explorer.address to allow for exposing the terrain explorer