### PR TITLE
feat: programmatically change world scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,28 @@ validate_model=true
 # Port for the local terrain explorer web UI (/td-explore).
 explorer.port=19801
 
+# Optional startup override for current world scale (1-6).
+# Without this setting, existing worlds keep their saved scale and new worlds default to 2.
+# world.current_scale=6
+
 # Spawn search: coarse-pixel region sizes for finding a land spawn near (0, 0).
 # Starts at initial_size x initial_size and expands by 8 each step up to max_size x max_size.
 # Each coarse pixel covers a large area (hundreds of blocks), so 16–128 is typically sufficient.
 spawn_search.initial_size=16
 spawn_search.max_size=128
 ```
+
+Current world scale can be overridden before Minecraft starts. Precedence is JVM system property, environment variable, then `world.current_scale` from the properties file:
+
+```bash
+java -Dterrain-diffusion-mc.current-scale=4 ...
+# or
+TERRAIN_DIFFUSION_MC_CURRENT_SCALE=4 ./gradlew runClient
+```
+
+Supported values are integers from `1` to `6`. A startup override replaces and persists the current world's saved scale. For newly created dedicated-server Terrain Diffusion worlds, it also selects the matching world height. Without an override, existing worlds keep their saved scale and new worlds use the original default of `2`. Mod integrations can call `WorldScaleManager.setCurrentScale(ServerWorld, int)` to update and persist the runtime scale of a loaded world.
+
+Changing scale after terrain has generated can create seams between old and new chunks. A loaded world's dimension height cannot be changed safely at runtime, so select the intended scale before creating the world.
 
 ### Per-world settings
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ validate_model=true
 explorer.port=19801
 
 # Optional startup override for current world scale (1-6).
-# Without this setting, existing worlds keep their saved scale and new worlds default to 2.
+# Applies only when initializing a world without a saved scale.
+# Clients also use it as the new-world UI value. Existing worlds always keep their saved scale.
 # world.current_scale=6
 
 # Spawn search: coarse-pixel region sizes for finding a land spawn near (0, 0).
@@ -86,7 +87,7 @@ java -Dterrain-diffusion-mc.current-scale=4 ...
 TERRAIN_DIFFUSION_MC_CURRENT_SCALE=4 ./gradlew runClient
 ```
 
-Supported values are integers from `1` to `6`. A startup override replaces and persists the current world's saved scale. For newly created dedicated-server Terrain Diffusion worlds, it also selects the matching world height. Without an override, existing worlds keep their saved scale and new worlds use the original default of `2`. Mod integrations can call `WorldScaleManager.setCurrentScale(ServerWorld, int)` to update and persist the runtime scale of a loaded world.
+Supported values are integers from `1` to `6`. A startup override applies only when initializing a world without a saved scale. For a newly created dedicated-server Terrain Diffusion world, it also selects the matching world height. On a client, it initializes the world-creation scale field, but the player's selection takes precedence. Existing dedicated-server and single-player worlds always keep their saved scale regardless of startup overrides. Without an override, new worlds use the original default of `2`. Mod integrations can call `WorldScaleManager.setCurrentScale(ServerWorld, int)` to explicitly update and persist the runtime scale of a loaded world.
 
 Changing scale after terrain has generated can create seams between old and new chunks. A loaded world's dimension height cannot be changed safely at runtime, so select the intended scale before creating the world.
 

--- a/src/client/java/com/github/xandergos/terraindiffusionmc/client/WorldScaleSettingsScreen.java
+++ b/src/client/java/com/github/xandergos/terraindiffusionmc/client/WorldScaleSettingsScreen.java
@@ -1,31 +1,22 @@
 package com.github.xandergos.terraindiffusionmc.client;
 
 import com.github.xandergos.terraindiffusionmc.world.WorldScaleManager;
+import com.github.xandergos.terraindiffusionmc.world.WorldScaleDimensionOptions;
 import com.github.xandergos.terraindiffusionmc.world.WorldScaleSelectionState;
 import net.minecraft.client.gui.screen.world.CreateWorldScreen;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.gui.widget.TextFieldWidget;
 import net.minecraft.client.gui.widget.TextWidget;
-import net.minecraft.registry.Registry;
 import net.minecraft.registry.RegistryKeys;
-import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
-import net.minecraft.util.Identifier;
 import net.minecraft.util.Formatting;
-import net.minecraft.world.dimension.DimensionOptions;
-import net.minecraft.world.dimension.DimensionOptionsRegistryHolder;
-import net.minecraft.world.dimension.DimensionType;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * World creation settings screen for selecting the initial terrain scale of a world.
  */
 public final class WorldScaleSettingsScreen extends Screen {
-    private static final String MOD_ID = "terrain-diffusion-mc";
     private static final int TEXT_FIELD_WIDTH = 80;
     private static final int TEXT_FIELD_HEIGHT = 20;
     private static final int BUTTON_WIDTH = 80;
@@ -124,40 +115,11 @@ public final class WorldScaleSettingsScreen extends Screen {
         }
 
         createWorldScreen.getWorldCreator().applyModifier((registryManager, selectedDimensions) -> {
-            DimensionOptionsRegistryHolder updatedDimensions =
-                    updateOverworldDimensionType(registryManager.getOrThrow(RegistryKeys.DIMENSION_TYPE),
-                            selectedDimensions, selectedScale);
-            return updatedDimensions == null ? selectedDimensions : updatedDimensions;
+            return WorldScaleDimensionOptions.withScaleDimensionType(
+                    registryManager.getOrThrow(RegistryKeys.DIMENSION_TYPE),
+                    selectedDimensions,
+                    selectedScale
+            );
         });
-    }
-
-    /**
-     * Replaces only the overworld dimension type entry with the scale-specific pre-registered one.
-     */
-    private DimensionOptionsRegistryHolder updateOverworldDimensionType(
-            Registry<DimensionType> dimensionTypeRegistry,
-            DimensionOptionsRegistryHolder selectedDimensions,
-            int selectedScale
-    ) {
-        DimensionOptions overworldOptions = selectedDimensions.getOrEmpty(DimensionOptions.OVERWORLD).orElse(null);
-        if (overworldOptions == null) {
-            return null;
-        }
-
-        Identifier dimensionTypeId = Identifier.of(MOD_ID, "terrain_diffusion_scale_" + selectedScale);
-        RegistryEntry.Reference<DimensionType> selectedDimensionTypeEntry = dimensionTypeRegistry.getEntry(dimensionTypeId).orElse(null);
-        if (selectedDimensionTypeEntry == null) {
-            return null;
-        }
-
-        DimensionOptions updatedOverworldOptions = new DimensionOptions(
-                selectedDimensionTypeEntry,
-                overworldOptions.chunkGenerator()
-        );
-
-        Map<net.minecraft.registry.RegistryKey<DimensionOptions>, DimensionOptions> updatedDimensionMap =
-                new HashMap<>(selectedDimensions.dimensions());
-        updatedDimensionMap.put(DimensionOptions.OVERWORLD, updatedOverworldOptions);
-        return new DimensionOptionsRegistryHolder(updatedDimensionMap);
     }
 }

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/config/TerrainDiffusionConfig.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/config/TerrainDiffusionConfig.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.Properties;
 
 public final class TerrainDiffusionConfig {
@@ -48,6 +49,15 @@ public final class TerrainDiffusionConfig {
     /** TCP port for the local terrain explorer HTTP server. */
     public static int explorerPort() {
         return readInt("explorer.port", DEFAULT_EXPLORER_PORT);
+    }
+
+    /** Optional startup override for the currently active world scale. */
+    public static Optional<String> currentWorldScale() {
+        String value = PROPERTIES.getProperty("world.current_scale");
+        if (value == null || value.isBlank()) {
+            return Optional.empty();
+        }
+        return Optional.of(value.trim());
     }
 
     /** Whether to validate SHA-256 for pre-existing local model files before use. */

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/mixin/ServerPropertiesHandlerMixin.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/mixin/ServerPropertiesHandlerMixin.java
@@ -1,0 +1,36 @@
+package com.github.xandergos.terraindiffusionmc.mixin;
+
+import com.github.xandergos.terraindiffusionmc.world.WorldScaleDimensionOptions;
+import com.github.xandergos.terraindiffusionmc.world.WorldScaleManager;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.RegistryWrapper;
+import net.minecraft.server.dedicated.ServerPropertiesHandler;
+import net.minecraft.world.dimension.DimensionOptionsRegistryHolder;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Applies the active world scale to newly created dedicated-server worlds.
+ */
+@Mixin(ServerPropertiesHandler.class)
+public class ServerPropertiesHandlerMixin {
+
+    @Inject(method = "createDimensionsRegistryHolder", at = @At("RETURN"), cancellable = true)
+    private void terrainDiffusionMc$applyCurrentWorldScale(
+            RegistryWrapper.WrapperLookup registryLookup,
+            CallbackInfoReturnable<DimensionOptionsRegistryHolder> callbackInfo
+    ) {
+        DimensionOptionsRegistryHolder dimensions = callbackInfo.getReturnValue();
+        if (!WorldScaleDimensionOptions.usesTerrainDiffusion(dimensions)) {
+            return;
+        }
+
+        callbackInfo.setReturnValue(WorldScaleDimensionOptions.withScaleDimensionType(
+                registryLookup.getOrThrow(RegistryKeys.DIMENSION_TYPE),
+                dimensions,
+                WorldScaleManager.getCurrentScale()
+        ));
+    }
+}

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/world/WorldScaleDimensionOptions.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/world/WorldScaleDimensionOptions.java
@@ -1,0 +1,53 @@
+package com.github.xandergos.terraindiffusionmc.world;
+
+import net.minecraft.registry.RegistryEntryLookup;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.util.Identifier;
+import net.minecraft.world.dimension.DimensionOptions;
+import net.minecraft.world.dimension.DimensionOptionsRegistryHolder;
+import net.minecraft.world.dimension.DimensionType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Applies scale-specific dimension types during world creation.
+ */
+public final class WorldScaleDimensionOptions {
+    private static final String MOD_ID = "terrain-diffusion-mc";
+
+    private WorldScaleDimensionOptions() {
+    }
+
+    /**
+     * Replaces only the overworld dimension type with the registered variant for the selected scale.
+     */
+    public static DimensionOptionsRegistryHolder withScaleDimensionType(
+            RegistryEntryLookup<DimensionType> dimensionTypeLookup,
+            DimensionOptionsRegistryHolder dimensions,
+            int configuredScale
+    ) {
+        DimensionOptions overworldOptions = dimensions.getOrEmpty(DimensionOptions.OVERWORLD).orElse(null);
+        if (overworldOptions == null) {
+            return dimensions;
+        }
+
+        int scale = WorldScaleManager.clampScale(configuredScale);
+        RegistryKey<DimensionType> dimensionTypeKey = RegistryKey.of(
+                RegistryKeys.DIMENSION_TYPE,
+                Identifier.of(MOD_ID, "terrain_diffusion_scale_" + scale)
+        );
+        RegistryEntry.Reference<DimensionType> dimensionTypeEntry = dimensionTypeLookup.getOrThrow(dimensionTypeKey);
+
+        DimensionOptions updatedOverworldOptions = new DimensionOptions(
+                dimensionTypeEntry,
+                overworldOptions.chunkGenerator()
+        );
+        Map<RegistryKey<DimensionOptions>, DimensionOptions> updatedDimensionMap =
+                new HashMap<>(dimensions.dimensions());
+        updatedDimensionMap.put(DimensionOptions.OVERWORLD, updatedOverworldOptions);
+        return new DimensionOptionsRegistryHolder(updatedDimensionMap);
+    }
+}

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/world/WorldScaleDimensionOptions.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/world/WorldScaleDimensionOptions.java
@@ -22,6 +22,16 @@ public final class WorldScaleDimensionOptions {
     }
 
     /**
+     * Returns whether the holder's overworld uses Terrain Diffusion generation.
+     */
+    public static boolean usesTerrainDiffusion(DimensionOptionsRegistryHolder dimensions) {
+        return dimensions.getOrEmpty(DimensionOptions.OVERWORLD)
+                .map(DimensionOptions::chunkGenerator)
+                .map(chunkGenerator -> chunkGenerator.getBiomeSource() instanceof TerrainDiffusionBiomeSource)
+                .orElse(false);
+    }
+
+    /**
      * Replaces only the overworld dimension type with the registered variant for the selected scale.
      */
     public static DimensionOptionsRegistryHolder withScaleDimensionType(

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/world/WorldScaleManager.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/world/WorldScaleManager.java
@@ -24,20 +24,23 @@ public final class WorldScaleManager {
     /**
      * Loads or creates per-world scale settings and sets the active runtime value.
      *
-     * <p>A configured current-scale override takes precedence over persisted state.
-     * Without one, an existing world keeps its saved scale. A new world uses its pending
-     * world-creation selection when present, otherwise {@value #DEFAULT_SCALE}.
+     * <p>A new world's pending world-creation selection takes precedence over a configured
+     * current-scale override. For existing worlds, the configured override takes precedence
+     * over persisted state. Without either, new worlds use {@value #DEFAULT_SCALE}.
      */
     public static void initializeForWorld(ServerWorld serverWorld) {
         WorldScaleSettingsState worldScaleSettingsState = serverWorld.getPersistentStateManager()
                 .getOrCreate(WorldScaleSettingsState.TYPE);
 
-        if (CONFIGURED_CURRENT_SCALE != null) {
-            worldScaleSettingsState.setScale(CONFIGURED_CURRENT_SCALE);
-        } else if (!worldScaleSettingsState.hasExplicitScale()) {
+        if (!worldScaleSettingsState.hasExplicitScale()) {
             Integer pendingScale = WorldScaleSelectionState.consumePendingScale();
-            int resolvedScale = pendingScale != null ? pendingScale : DEFAULT_SCALE;
+            int resolvedScale = CONFIGURED_CURRENT_SCALE != null ? CONFIGURED_CURRENT_SCALE : DEFAULT_SCALE;
+            if (pendingScale != null) {
+                resolvedScale = pendingScale;
+            }
             worldScaleSettingsState.setScale(resolvedScale);
+        } else if (CONFIGURED_CURRENT_SCALE != null) {
+            worldScaleSettingsState.setScale(CONFIGURED_CURRENT_SCALE);
         }
 
         currentScale = clampScale(worldScaleSettingsState.getScale());

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/world/WorldScaleManager.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/world/WorldScaleManager.java
@@ -17,9 +17,7 @@ public final class WorldScaleManager {
     private static final String CURRENT_SCALE_ENVIRONMENT_VARIABLE = "TERRAIN_DIFFUSION_MC_CURRENT_SCALE";
 
     private static final Integer CONFIGURED_CURRENT_SCALE = resolveConfiguredCurrentScale();
-    private static volatile int currentScale = CONFIGURED_CURRENT_SCALE != null
-            ? CONFIGURED_CURRENT_SCALE
-            : DEFAULT_SCALE;
+    private static volatile int currentScale = getStartupScale();
 
     private WorldScaleManager() {
     }
@@ -39,7 +37,7 @@ public final class WorldScaleManager {
 
         if (!hasSavedScale) {
             Integer pendingScale = WorldScaleSelectionState.consumePendingScale();
-            int resolvedScale = CONFIGURED_CURRENT_SCALE != null ? CONFIGURED_CURRENT_SCALE : DEFAULT_SCALE;
+            int resolvedScale = getStartupScale();
             if (pendingScale != null) {
                 resolvedScale = pendingScale;
                 scaleSource = "world creation selection";
@@ -70,6 +68,13 @@ public final class WorldScaleManager {
      */
     public static int getCurrentScale() {
         return currentScale;
+    }
+
+    /**
+     * Returns the configured startup override, or the fixed default when none is configured.
+     */
+    static int getStartupScale() {
+        return CONFIGURED_CURRENT_SCALE != null ? CONFIGURED_CURRENT_SCALE : DEFAULT_SCALE;
     }
 
     /**

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/world/WorldScaleManager.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/world/WorldScaleManager.java
@@ -2,11 +2,14 @@ package com.github.xandergos.terraindiffusionmc.world;
 
 import com.github.xandergos.terraindiffusionmc.config.TerrainDiffusionConfig;
 import net.minecraft.server.world.ServerWorld;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Runtime access for world-scoped terrain scale.
  */
 public final class WorldScaleManager {
+    private static final Logger LOG = LoggerFactory.getLogger(WorldScaleManager.class);
     public static final int DEFAULT_SCALE = 2;
     private static final int MIN_SCALE = 1;
     public static final int MAX_SCALE = 6;
@@ -31,19 +34,35 @@ public final class WorldScaleManager {
     public static void initializeForWorld(ServerWorld serverWorld) {
         WorldScaleSettingsState worldScaleSettingsState = serverWorld.getPersistentStateManager()
                 .getOrCreate(WorldScaleSettingsState.TYPE);
+        boolean hasSavedScale = worldScaleSettingsState.hasExplicitScale();
+        String scaleSource;
 
-        if (!worldScaleSettingsState.hasExplicitScale()) {
+        if (!hasSavedScale) {
             Integer pendingScale = WorldScaleSelectionState.consumePendingScale();
             int resolvedScale = CONFIGURED_CURRENT_SCALE != null ? CONFIGURED_CURRENT_SCALE : DEFAULT_SCALE;
             if (pendingScale != null) {
                 resolvedScale = pendingScale;
+                scaleSource = "world creation selection";
+            } else if (CONFIGURED_CURRENT_SCALE != null) {
+                scaleSource = "startup override";
+            } else {
+                scaleSource = "default";
             }
             worldScaleSettingsState.setScale(resolvedScale);
         } else if (CONFIGURED_CURRENT_SCALE != null) {
             worldScaleSettingsState.setScale(CONFIGURED_CURRENT_SCALE);
+            scaleSource = "startup override";
+        } else {
+            scaleSource = "saved world";
         }
 
         currentScale = clampScale(worldScaleSettingsState.getScale());
+        LOG.info("{} {} world '{}' with terrain scale {} ({})",
+                hasSavedScale ? "Opened existing" : "Initialized new/unconfigured",
+                serverWorld.getServer().isDedicated() ? "dedicated-server" : "single-player",
+                serverWorld.getRegistryKey().getValue(),
+                currentScale,
+                scaleSource);
     }
 
     /**
@@ -62,6 +81,9 @@ public final class WorldScaleManager {
                 .getOrCreate(WorldScaleSettingsState.TYPE);
         worldScaleSettingsState.setScale(clampedScale);
         currentScale = clampedScale;
+        LOG.info("Changed terrain scale for world '{}' to {} (programmatic update)",
+                serverWorld.getRegistryKey().getValue(),
+                currentScale);
     }
 
     /**

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/world/WorldScaleManager.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/world/WorldScaleManager.java
@@ -26,8 +26,8 @@ public final class WorldScaleManager {
      * Loads or creates per-world scale settings and sets the active runtime value.
      *
      * <p>A new world's pending world-creation selection takes precedence over a configured
-     * current-scale override. For existing worlds, the configured override takes precedence
-     * over persisted state. Without either, new worlds use {@value #DEFAULT_SCALE}.
+     * current-scale override. Every existing world keeps its persisted scale regardless of
+     * startup overrides. Without either, new worlds use {@value #DEFAULT_SCALE}.
      */
     public static void initializeForWorld(ServerWorld serverWorld) {
         WorldScaleSettingsState worldScaleSettingsState = serverWorld.getPersistentStateManager()
@@ -47,9 +47,6 @@ public final class WorldScaleManager {
                 scaleSource = "default";
             }
             worldScaleSettingsState.setScale(resolvedScale);
-        } else if (CONFIGURED_CURRENT_SCALE != null) {
-            worldScaleSettingsState.setScale(CONFIGURED_CURRENT_SCALE);
-            scaleSource = "startup override";
         } else {
             scaleSource = "saved world";
         }

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/world/WorldScaleManager.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/world/WorldScaleManager.java
@@ -1,5 +1,6 @@
 package com.github.xandergos.terraindiffusionmc.world;
 
+import com.github.xandergos.terraindiffusionmc.config.TerrainDiffusionConfig;
 import net.minecraft.server.world.ServerWorld;
 
 /**
@@ -9,8 +10,13 @@ public final class WorldScaleManager {
     public static final int DEFAULT_SCALE = 2;
     private static final int MIN_SCALE = 1;
     public static final int MAX_SCALE = 6;
+    private static final String CURRENT_SCALE_SYSTEM_PROPERTY = "terrain-diffusion-mc.current-scale";
+    private static final String CURRENT_SCALE_ENVIRONMENT_VARIABLE = "TERRAIN_DIFFUSION_MC_CURRENT_SCALE";
 
-    private static volatile int currentScale = DEFAULT_SCALE;
+    private static final Integer CONFIGURED_CURRENT_SCALE = resolveConfiguredCurrentScale();
+    private static volatile int currentScale = CONFIGURED_CURRENT_SCALE != null
+            ? CONFIGURED_CURRENT_SCALE
+            : DEFAULT_SCALE;
 
     private WorldScaleManager() {
     }
@@ -18,14 +24,17 @@ public final class WorldScaleManager {
     /**
      * Loads or creates per-world scale settings and sets the active runtime value.
      *
-     * <p>If the world has no explicit stored scale yet, this applies pending
-     * world-creation selection when present, otherwise falls back to {@value #DEFAULT_SCALE}.
+     * <p>A configured current-scale override takes precedence over persisted state.
+     * Without one, an existing world keeps its saved scale. A new world uses its pending
+     * world-creation selection when present, otherwise {@value #DEFAULT_SCALE}.
      */
     public static void initializeForWorld(ServerWorld serverWorld) {
         WorldScaleSettingsState worldScaleSettingsState = serverWorld.getPersistentStateManager()
                 .getOrCreate(WorldScaleSettingsState.TYPE);
 
-        if (!worldScaleSettingsState.hasExplicitScale()) {
+        if (CONFIGURED_CURRENT_SCALE != null) {
+            worldScaleSettingsState.setScale(CONFIGURED_CURRENT_SCALE);
+        } else if (!worldScaleSettingsState.hasExplicitScale()) {
             Integer pendingScale = WorldScaleSelectionState.consumePendingScale();
             int resolvedScale = pendingScale != null ? pendingScale : DEFAULT_SCALE;
             worldScaleSettingsState.setScale(resolvedScale);
@@ -57,5 +66,37 @@ public final class WorldScaleManager {
      */
     public static int clampScale(int configuredScale) {
         return Math.max(MIN_SCALE, Math.min(MAX_SCALE, configuredScale));
+    }
+
+    private static Integer resolveConfiguredCurrentScale() {
+        String systemPropertyScale = System.getProperty(CURRENT_SCALE_SYSTEM_PROPERTY);
+        if (systemPropertyScale != null) {
+            return parseConfiguredCurrentScale(systemPropertyScale,
+                    "system property " + CURRENT_SCALE_SYSTEM_PROPERTY);
+        }
+
+        String environmentScale = System.getenv(CURRENT_SCALE_ENVIRONMENT_VARIABLE);
+        if (environmentScale != null) {
+            return parseConfiguredCurrentScale(environmentScale,
+                    "environment variable " + CURRENT_SCALE_ENVIRONMENT_VARIABLE);
+        }
+
+        return TerrainDiffusionConfig.currentWorldScale()
+                .map(value -> parseConfiguredCurrentScale(value, "configuration property world.current_scale"))
+                .orElse(null);
+    }
+
+    private static Integer parseConfiguredCurrentScale(String rawScale, String source) {
+        try {
+            int configuredScale = Integer.parseInt(rawScale.trim());
+            if (configuredScale >= MIN_SCALE && configuredScale <= MAX_SCALE) {
+                return configuredScale;
+            }
+        } catch (NumberFormatException ignored) {
+        }
+        System.err.println("Invalid world scale from " + source + ": " + rawScale
+                + "; expected an integer from " + MIN_SCALE + " to " + MAX_SCALE
+                + ", ignoring override");
+        return null;
     }
 }

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/world/WorldScaleSelectionState.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/world/WorldScaleSelectionState.java
@@ -29,10 +29,10 @@ public final class WorldScaleSelectionState {
     }
 
     /**
-     * Returns the currently selected pending scale, or the default if none is set.
+     * Returns the currently selected pending scale, or the configured startup scale if none is set.
      */
     public static int getPendingScaleOrDefault() {
         Integer pendingScale = PENDING_SCALE.get();
-        return pendingScale != null ? pendingScale : WorldScaleManager.DEFAULT_SCALE;
+        return pendingScale != null ? pendingScale : WorldScaleManager.getStartupScale();
     }
 }

--- a/src/main/java/com/github/xandergos/terraindiffusionmc/world/WorldScaleSettingsState.java
+++ b/src/main/java/com/github/xandergos/terraindiffusionmc/world/WorldScaleSettingsState.java
@@ -5,6 +5,8 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.world.PersistentState;
 import net.minecraft.world.PersistentStateType;
 
+import java.util.Optional;
+
 /**
  * Persisted per-world settings for terrain diffusion.
  *
@@ -12,9 +14,12 @@ import net.minecraft.world.PersistentStateType;
  */
 public final class WorldScaleSettingsState extends PersistentState {
     private static final Codec<WorldScaleSettingsState> CODEC = RecordCodecBuilder.create(instance -> instance.group(
-            Codec.INT.optionalFieldOf("scale", WorldScaleManager.DEFAULT_SCALE).forGetter(WorldScaleSettingsState::getScale),
+            Codec.INT.optionalFieldOf("scale").forGetter(state -> Optional.of(state.getScale())),
             Codec.BOOL.optionalFieldOf("explicit_scale", false).forGetter(WorldScaleSettingsState::hasExplicitScale)
-    ).apply(instance, WorldScaleSettingsState::new));
+    ).apply(instance, (savedScale, hasExplicitScale) -> new WorldScaleSettingsState(
+            savedScale.orElse(WorldScaleManager.DEFAULT_SCALE),
+            hasExplicitScale
+    )));
 
     private int scale;
     private boolean explicitScale;

--- a/src/main/resources/terrain-diffusion-mc.mixins.json
+++ b/src/main/resources/terrain-diffusion-mc.mixins.json
@@ -5,7 +5,8 @@
   "compatibilityLevel": "JAVA_21",
   "mixins": [
     "BiomeMixin",
-    "MinecraftServerMixin"
+    "MinecraftServerMixin",
+    "ServerPropertiesHandlerMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/main/resources/terrain-diffusion-mc.properties
+++ b/src/main/resources/terrain-diffusion-mc.properties
@@ -17,7 +17,8 @@ validate_model=true
 explorer.port=19801
 
 # Optional startup override for current world scale. Must be an integer from 1 to 6.
-# Without this setting, existing worlds keep their saved scale and new worlds default to 2.
+# Applies only when initializing a world without a saved scale.
+# Clients also use it as the new-world UI value. Existing worlds always keep their saved scale.
 # world.current_scale=6
 
 # Terrain generation region side length in blocks. Must be a power of 2.

--- a/src/main/resources/terrain-diffusion-mc.properties
+++ b/src/main/resources/terrain-diffusion-mc.properties
@@ -16,6 +16,10 @@ validate_model=true
 # Port for the local terrain explorer web UI (started with /td-explore command).
 explorer.port=19801
 
+# Optional startup override for current world scale. Must be an integer from 1 to 6.
+# Without this setting, existing worlds keep their saved scale and new worlds default to 2.
+# world.current_scale=6
+
 # Terrain generation region side length in blocks. Must be a power of 2.
 # Examples: 128, 256, 512, 1024.
 # Use larger values to generate in larger batches (more chunks per second)


### PR DESCRIPTION
I wanted this feature so it's possible to change the `Terrain diffusion` world type's `World scale` programmatically/via config for servers.

A Minecraft server usually doesn't have a GUI, and so it's not possible to select the `World scale` as you would do on a Minecraft client, resulting in its value always being `2`.

Now a server can either pass a JVM argument, set an environment variable, or write to the mod's config file which `World scale` to use.